### PR TITLE
fix #28, issues with print in version 2.7

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1,6 +1,7 @@
 # Author: Leland McInnes <leland.mcinnes@gmail.com>
 #
 # License: BSD 3 clause
+from __future__ import print_function
 from collections import deque, namedtuple
 from warnings import warn
 
@@ -452,7 +453,7 @@ def make_nn_descent(dist, dist_args):
 
         for n in range(n_iters):
             if verbose:
-                print("\tnn descent iteration ", n, " / ", n_iters)
+                print("\t", n, " / ", n_iters)
 
             candidate_neighbors = build_candidates(current_graph, n_vertices,
                                                    n_neighbors, max_candidates,
@@ -1026,7 +1027,7 @@ def optimize_layout(embedding, positive_head, positive_tail,
                 alpha = initial_alpha * 0.000001
 
         if verbose and i % int(n_edge_samples/10) == 0 :
-            print("\tembedding iteration ", i, " / ", n_edge_samples)
+            print("\t", i, " / ", n_edge_samples)
 
     return embedding
 


### PR DESCRIPTION
This implements a fix for issue #28.  It seems to be caused because`print` is a statement in 2.7 but a function in 3. Importing print function fixed the issue.

I've tested the digits example on 2.7 and 3.6 and everything seems to work fine.