### PR TITLE
dynamically add __version__ variable based on what's in setup.py

### DIFF
--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -1,2 +1,4 @@
 from .umap_ import UMAP
-__version__ = "0.2.1"
+
+import pkg_resources
+__version__ = pkg_resources.get_distribution('umap-learn').version


### PR DESCRIPTION
This is an alternative fix for #46. This will print the version number that is set in the setup file so you only have to change the version number in one place.

> Hopefully I can keep this all synced.

Now you won't have to worry about it.  