### PR TITLE
recognize notebooks as python code 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
Notebooks produce so many lines of code that they conflate the language statistics. This .gitattributes line makes it so ipynb notebooks are recognized as Python code.

This is useful for GitHub, library.io, and pypi classifications and will make UMAP easier for Python developers to find. 