### PR TITLE
Minor fix with defaults for weighted minkowski

### DIFF
--- a/umap/distances.py
+++ b/umap/distances.py
@@ -83,7 +83,7 @@ def minkowski(x, y, p=2):
 
 
 @numba.njit()
-def weighted_minkowski(x, y, w=_mock_identity, p=2):
+def weighted_minkowski(x, y, w=_mock_ones, p=2):
     """A weighted version of Minkowski distance.
 
     ..math::


### PR DESCRIPTION
Hi, I’m not completely sure if this is correct, but it seems like the default value for `w` in `weighted_minkowski` should be `_mock_ones` instead of `_mock_identity`.