### PR TITLE
Fixes transform method typo

### DIFF
--- a/doc/supervised.rst
+++ b/doc/supervised.rst
@@ -316,7 +316,7 @@ As you can see this has done a similar job as before, successfully
 embedding the separate classes while retaining both the internal
 structure and the overall global structure. We can now look at how the
 test set, for which we provided no label information, was embedded via
-the `:meth:`~umap.umap_.UMAP.transform` method.
+the :meth:`~umap.umap_.UMAP.transform` method.
 
 .. code:: python3
 


### PR DESCRIPTION
I ran across a typo that caused a link to the `UMAP.transform` method to not be rendered correctly. This PR simply fixes the typo. 

With typo:

![screen shot 2018-09-05 at 2 50 12 pm](https://user-images.githubusercontent.com/11656932/45117478-5ef2bd80-b11b-11e8-975d-e5810d0021f6.png)

After fix:

![screen shot 2018-09-05 at 2 50 20 pm](https://user-images.githubusercontent.com/11656932/45117485-631edb00-b11b-11e8-8313-afddbdd78e6a.png)
