### PR TITLE
Change LICENSE.txt to have the actual BSD 3-Clause License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-BSD 2-Clause License
+BSD 3-Clause License
 
 Copyright (c) 2017, Leland McInnes
 All rights reserved.
@@ -12,6 +12,10 @@ modification, are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE


### PR DESCRIPTION
The source code and README.rst all indicate the BSD 3-Clause License should be used, but the LICENSE.txt file itself is the BSD 2-Clause License.  The PR makes the LICENSE.txt file match the code comments.