### PR TITLE
Appveyor Windows CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@
 .. image:: https://travis-ci.org/lmcinnes/umap.svg
     :target: https://travis-ci.org/lmcinnes/umap
     :alt: Travis Build Status
+.. image:: https://ci.appveyor.com/api/projects/status/github/lmcinnes/umap?branch=master&svg=true
+    :target: https://ci.appveyor.com/project/lmcinnes/umap
+    :alt: AppVeyor Build Status
 .. image:: https://coveralls.io/repos/github/lmcinnes/umap/badge.svg
     :target: https://coveralls.io/github/lmcinnes/umap
     :alt: Test Coverage Status

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,9 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose umap-learn"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose"
   - activate test-environment
+  - pip install -e .
 
 test_script:
   - nosetests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+build: "off"
+
+environment:
+  matrix:
+    - PYTHON_VERSION: "3.6"
+      MINICONDA: C:\Miniconda36-x64
+    - PYTHON_VERSION: "3.7"
+      MINICONDA: C:\Miniconda3-x64
+
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose"
+  - activate test-environment
+
+test_script:
+  - nosetests
+  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba nose umap-learn"
   - activate test-environment
 
 test_script:


### PR DESCRIPTION
I would like to get UMAP's code-coverage and non-JITted CI completing again. First step: add Windows CI, so I can detect and fix any Windows-specific oddities. 

This is basically the same as https://github.com/lmcinnes/pynndescent/pull/21 -- you will need to activate the project on appveyor's home page.
