### PR TITLE
Optimize smooth_knn_dist

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -89,6 +89,8 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
     rho = np.zeros(distances.shape[0])
     result = np.zeros(distances.shape[0])
 
+    mean_distances = np.mean(distances)
+
     for i in range(distances.shape[0]):
         lo = 0.0
         hi = NPY_INFINITY
@@ -137,11 +139,12 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
 
         # TODO: This is very inefficient, but will do for now. FIXME
         if rho[i] > 0.0:
-            if result[i] < MIN_K_DIST_SCALE * np.mean(ith_distances):
-                result[i] = MIN_K_DIST_SCALE * np.mean(ith_distances)
+            mean_ith_distances = np.mean(ith_distances)
+            if result[i] < MIN_K_DIST_SCALE * mean_ith_distances:
+                result[i] = MIN_K_DIST_SCALE * mean_ith_distances
         else:
-            if result[i] < MIN_K_DIST_SCALE * np.mean(distances):
-                result[i] = MIN_K_DIST_SCALE * np.mean(distances)
+            if result[i] < MIN_K_DIST_SCALE * mean_distances:
+                result[i] = MIN_K_DIST_SCALE * mean_distances
 
     return result, rho
 

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -45,7 +45,7 @@ MIN_K_DIST_SCALE = 1e-3
 NPY_INFINITY = np.inf
 
 
-@numba.njit(parallel=True, fastmath=True)
+@numba.njit(fastmath=True) # benchmarking `parallel=True` shows it to *decrease* performance
 def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1.0):
     """Compute a continuous version of the distance to the kth nearest
     neighbor. That is, this is similar to knn-distance but allows continuous


### PR DESCRIPTION
During benchmarking, I found that the use of `parallel=True` in `smooth_knn_dist` significantly hurts performance.

I used the code in this PR and the following benchmark script.
```python
import numpy as np
import time
from umap.umap_ import nearest_neighbors, smooth_knn_dist

X = np.random.rand(100000, 50)

knn_indices, knn_dists, _ = nearest_neighbors(
    X, 15, "euclidean", {}, False, np.random, verbose=True
)

t0 = time.time()
smooth_knn_dist(knn_dists, 25, 1.0)
t1 = time.time()
print("smooth_knn_dist took:", t1-t0)
```

With `parallel=True` (before):
```
smooth_knn_dist took: 11.318735122680664
```

Without `parallel=True` (after):
```
smooth_knn_dist took: 1.1395599842071533
```

So it's about ten times as fast when `parallel=True` is not used.

I ran with `NUMBA_PARALLEL_DIAGNOSTICS=4` and this confirmed that it was not optimizing the loops, but it didn't explain why the code ran slower with  `parallel=True`. I also tried using `numba.prange` instead of regular `range`, but this didn't give a speed up and in fact made the code slightly slower.