### PR TITLE
Fix Spivak reference in "How UMAP works"

### DIFF
--- a/doc/how_umap_works.rst
+++ b/doc/how_umap_works.rst
@@ -326,10 +326,10 @@ functors from algebraic topology and then adapting them to apply to
 metric spaces and fuzzy simplicial sets. The mathematics involved in
 this is outside the scope of this exposition, but for those interested
 you can look at the `original work on this by David
-Spivak <https://en.wikipedia.org/wiki/Riemannian_geometry>`__ and our
-`paper <https://arxiv.org/abs/1802.03426>`__. It will have to suffice to
-say that there is some mathematical machinery that lets us realize this
-intuition in a well defined way.
+Spivak <http://math.mit.edu/~dspivak/files/metric_realization.pdf>`__
+and our `paper <https://arxiv.org/abs/1802.03426>`__. It will have to
+suffice to say that there is some mathematical machinery that lets us
+realize this intuition in a well defined way.
 
 This resolves a number of issues, but a new problem presents itself when
 we apply this sort of process to real data, especially in higher


### PR DESCRIPTION
Let me know if this should go into master rather than 0.4dev.

There's also a formatting issue with the one use of latex in "How UMAP works" (line 405/406), but I'm not familiar enough with reStructuredText to know how to fix it.