### PR TITLE
Fix deprecation warning with scikit-learn 0.21

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -13,9 +13,9 @@ from sklearn.preprocessing import normalize
 from sklearn.neighbors import KDTree
 
 try:
-    from joblib
+    import joblib
 except ImportError:
-    # sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23
+    # sklearn.externals.joblib is deprecated in 0.21, will be removed in 0.23
     from sklearn.externals import joblib
 
 import numpy as np

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -12,7 +12,11 @@ from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import normalize
 from sklearn.neighbors import KDTree
 
-from sklearn.externals import joblib
+try:
+    from joblib
+except ImportError:
+    # sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23
+    from sklearn.externals import joblib
 
 import numpy as np
 import scipy.sparse


### PR DESCRIPTION
sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23.

This change uses the joblib library directly, if available; Otherwise it falls back to sklearn.externals.joblib, which seems like the least intrusive way of making this change.