### PR TITLE
Adding MacOS builds for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+os:
+  - linux
+  - osx
+
 cache:
   apt: true
   # We use three different cache directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-os:
-  - linux
-  - osx
-
 cache:
   apt: true
   # We use three different cache directory
@@ -20,8 +16,17 @@ env:
 matrix:
   include:
     - python: 3.6
+      os: linux
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
+      os: linux
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
+      os: linux
+    - python: 3.6
+      os: osx
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
+      os: osx
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
+      os: osx
 
 install: source ci_scripts/install.sh
 script: bash ci_scripts/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ matrix:
       os: linux
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
       os: linux
-    - python: 3.6
-      os: osx
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
       os: osx
+      language: generic
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
       os: osx
+      language: generic
 
 install: source ci_scripts/install.sh
 script: bash ci_scripts/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
       os: osx
       language: generic
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1"
       os: osx
       language: generic
 

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -13,14 +13,23 @@ if [[ "$DISTRIB" == "conda" ]]; then
   echo "Cached in $HOME/download :"
   ls -l
   echo
-  if [[ ! -f miniconda.sh ]]
-     then
-     wget http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh \
+# For now, ignoring the cached file.
+#  if [[ ! -f miniconda.sh ]]
+#     then
+     if [ $TRAVIS_OS_NAME = 'osx' ]; then
+       # MacOS URL found here: https://docs.conda.io/en/latest/miniconda.html
+       wget \
+       https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh \
+         -O miniconda.sh
+     else
+       wget \
+       http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh \
          -O miniconda.sh
      fi
-  chmod +x miniconda.sh && ./miniconda.sh -b
+#  fi
+  chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
   cd ..
-  export PATH=/home/travis/miniconda/bin:$PATH
+  export PATH=$HOME/miniconda/bin:$PATH
   conda update --yes conda
   popd
 

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -2,7 +2,10 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
   # Deactivate the travis-provided virtual environment and setup a
     # conda-based environment instead
-  deactivate
+  if [ $TRAVIS_OS_NAME = 'linux' ]; then
+    # Only Linux has a virtual environment activated; Mac does not.
+    deactivate
+  fi
 
   # Use the miniconda installer for faster download / install of conda
   # itself


### PR DESCRIPTION
I recently figured out how to get Travis to run tests on MacOS so I figured I'd add the functionality to umap.

I'm not 100% sure this will work; I'm mainly making this PR to trigger a Travis build so we can see what happens.

For simplicity, I've removed the check in `ci_scripts/install.sh` to use the cached version of `miniconda.sh`, because now there can be two different versions of that file. The best way to handle this would be to name them differently. That said, according to [the Travis docs](https://docs.travis-ci.com/user/caching/#things-not-to-cache), caching these downloads probably won't improve the build time. Specifically, it says "Large files that are quick to install but slow to download do not benefit from caching, as they take as long to download from the cache as from the original source".