### PR TITLE
Add check for sparse matrix in fit

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1509,10 +1509,11 @@ class UMAP(BaseEstimator):
                 # )
 
         if y is not None:
-            if len(X) != len(y):
+            len_X = len(X) if not scipy.sparse.issparse(X) else X.shape[0]
+            if len_X != len(y):
                 raise ValueError(
                     "Length of x = {len_x}, length of y = {len_y}, while it must be equal.".format(
-                        len_x=len(X), len_y=len(y)
+                        len_x=len_X, len_y=len(y)
                     )
                 )
             y_ = check_array(y, ensure_2d=False)


### PR DESCRIPTION
Without this check, calling `len` on sparse matrices is ambiguous, and an error is thrown:
```
  File "../pythonEnv/lib/python3.6/site-packages/umap/umap_.py", line 1641, in fit_transform
    self.fit(X, y)
  File "../pythonEnv/lib/python3.6/site-packages/umap/umap_.py", line 1496, in fit
    if len(X) != len(y):
  File "../pythonEnv/lib/python3.6/site-packages/scipy/sparse/base.py", line 296, in __len__
    raise TypeError("sparse matrix length is ambiguous; use getnnz()"
```