### PR TITLE
Remove hardcoded special distance metrics and check sklearn first

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1423,15 +1423,13 @@ class UMAP(BaseEstimator):
         # Handle small cases efficiently by computing all distances
         if X.shape[0] < 4096 and not self.force_approximation_algorithm:
             self._small_data = True
-
-            if self.metric in ("ll_dirichlet", "hellinger"):
+            try:
+                dmat = pairwise_distances(X, metric=self.metric, **self._metric_kwds)
+            except ValueError: # metric is not supported by sklearn, fallback to pairwise special
                 if self._sparse_data:
                     dmat = dist.pairwise_special_metric(X.toarray(), metric=self.metric)
                 else:
                     dmat = dist.pairwise_special_metric(X, metric=self.metric)
-            else:
-                dmat = pairwise_distances(X, metric=self.metric, **self._metric_kwds)
-
             self.graph_, self._sigmas, self._rhos = fuzzy_simplicial_set(
                 dmat,
                 self._n_neighbors,


### PR DESCRIPTION
If the number of datapoints are fewer than 4096, all pairwise distances are computed. sklearn-supported metrics are calculated via sklearn's `pairwise_distances` function and umap-only metrics are done via custom `dist.pairwise_special_metric` function. Instead of maintaining a list of umap-specific metrics here, I think it's easier to first check if sklearn supports a metric and then to fallback to custom function if not. Because, as we add new distance functions, it gets more cumbersome to maintain a list of special distance metrics that are not supported by sklearn e.g. poincare is missing right now.

There is a function in sklearn to get an incomplete list of supported metrics (https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/pairwise.py#L1147) but the full list is stored in a private list (https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/pairwise.py#L1237).

Therefore, I changed the code such that it first tries sklearn function first and falls back to custom function if it throws a ValueError (https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/pairwise.py#L1532).