### PR TITLE
Fix 179: allow projection if .embedding_ set to non float32

### DIFF
--- a/umap/tests/test_umap.py
+++ b/umap/tests/test_umap.py
@@ -750,6 +750,22 @@ def test_umap_transform_on_iris():
     )
 
 
+def test_umap_transform_on_iris_modified_dtype():
+    data = iris.data[iris_selection]
+    fitter = UMAP(n_neighbors=10, min_dist=0.01, random_state=42).fit(data)
+    fitter.embedding_ = fitter.embedding_.astype(np.float64)
+
+    new_data = iris.data[~iris_selection]
+    embedding = fitter.transform(new_data)
+
+    trust = trustworthiness(new_data, embedding, 10)
+    assert_greater_equal(
+        trust,
+        0.89,
+        "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust),
+    )
+
+
 # # This test is currently to expensive to run when turning
 # # off numba JITting to detect coverage.
 # @SkipTest

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1709,7 +1709,7 @@ class UMAP(BaseEstimator):
 
         embedding = optimize_layout(
             embedding,
-            self.embedding_,
+            self.embedding_.astype(np.float32, copy=False),  # Fix #179
             head,
             tail,
             n_epochs,


### PR DESCRIPTION
Fixes #179

This meets the expectation that the embeddings passed to optimize_layout are float32. In the typical case, where they are float32, this should be no cost. When the stored embedding is not float32, this is a pretty cheap operation (13ms for ten million elements). Potentially, the existing embedding could be converted and re-stored as a float32 array (saving future conversions), but this could increase memory usage and break expectations about references.

As proof this works, the added test fails on c61cdfe124ff (current master) but passes here.

Edit: So travis failed, but it looks like condas servers are down at the moment. I'd appreciate a rebuild once they're back up!