### PR TITLE
Allow non float32[:] init for simplical_set_embedding

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -985,7 +985,9 @@ def simplicial_set_embedding(
                     scale=0.001 * nndist, size=init_data.shape
                 ).astype(np.float32)
             else:
-                embedding = init_data
+                embedding = check_array(
+                    init_data, dtype=np.float32, accept_sparse=False
+                )
 
     epochs_per_sample = make_epochs_per_sample(graph.data, n_epochs)
 


### PR DESCRIPTION
I realized #261 didn't quite solve https://github.com/theislab/scanpy/issues/666, since we just call `simplical_set_embedding` when we provide our own initial position. This way, anyone can pass whatever initial positions to `simplicial_set_embedding` without worrying about the dtypes. At this point, I wonder if it's worth putting a wrapper around `optimize_layout` to handle all required casting.

I'm a little on the fence about how useful the added test is. It does the job of failing if `simplical_set_embedding` can't handle non-float32 arrays for `init`. However, I wouldn't be surprised if it were flaky on various platforms since I can't exactly replicate the random state.