### PR TITLE
Add a fast way to compute knn_indices 

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -58,7 +58,13 @@ NPY_INFINITY = np.inf
 @numba.njit(
     fastmath=True
 )  # benchmarking `parallel=True` shows it to *decrease* performance
-def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1.0):
+def smooth_knn_dist(
+    distances,
+    k,
+    n_iter=64,
+    local_connectivity=1.0,
+    bandwidth=1.0,
+):
     """Compute a continuous version of the distance to the kth nearest
     neighbor. That is, this is similar to knn-distance but allows continuous
     k values rather than requiring an integral k. In essence we are simply
@@ -118,7 +124,8 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
                 rho[i] = non_zero_dists[index - 1]
                 if interpolation > SMOOTH_K_TOLERANCE:
                     rho[i] += interpolation * (
-                        non_zero_dists[index] - non_zero_dists[index - 1]
+                        non_zero_dists[index]
+                        - non_zero_dists[index - 1]
                     )
             else:
                 rho[i] = interpolation * non_zero_dists[0]
@@ -153,17 +160,33 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
         # TODO: This is very inefficient, but will do for now. FIXME
         if rho[i] > 0.0:
             mean_ith_distances = np.mean(ith_distances)
-            if result[i] < MIN_K_DIST_SCALE * mean_ith_distances:
-                result[i] = MIN_K_DIST_SCALE * mean_ith_distances
+            if (
+                result[i]
+                < MIN_K_DIST_SCALE * mean_ith_distances
+            ):
+                result[i] = (
+                    MIN_K_DIST_SCALE * mean_ith_distances
+                )
         else:
-            if result[i] < MIN_K_DIST_SCALE * mean_distances:
-                result[i] = MIN_K_DIST_SCALE * mean_distances
+            if (
+                result[i]
+                < MIN_K_DIST_SCALE * mean_distances
+            ):
+                result[i] = (
+                    MIN_K_DIST_SCALE * mean_distances
+                )
 
     return result, rho
 
 
 def nearest_neighbors(
-    X, n_neighbors, metric, metric_kwds, angular, random_state, verbose=False
+    X,
+    n_neighbors,
+    metric,
+    metric_kwds,
+    angular,
+    random_state,
+    verbose=False,
 ):
     """Compute the ``n_neighbors`` nearest points for each data point in ``X``
     under ``metric``. This may be exact, but more likely is approximated via
@@ -209,7 +232,9 @@ def nearest_neighbors(
         knn_indices = fast_knn_indices(X, n_neighbors)
         # Compute the nearest neighbor distances
         #   (equivalent to np.sort(X)[:,:n_neighbors])
-        knn_dists = X[np.arange(X.shape[0])[:, None], knn_indices].copy()
+        knn_dists = X[
+            np.arange(X.shape[0])[:, None], knn_indices
+        ].copy()
 
         rp_forest = []
     else:
@@ -218,37 +243,66 @@ def nearest_neighbors(
         elif metric in dist.named_distances:
             distance_func = dist.named_distances[metric]
         else:
-            raise ValueError("Metric is neither callable, " + "nor a recognised string")
+            raise ValueError(
+                "Metric is neither callable, "
+                + "nor a recognised string"
+            )
 
-        if metric in ("cosine", "correlation", "dice", "jaccard"):
+        if metric in (
+            "cosine",
+            "correlation",
+            "dice",
+            "jaccard",
+        ):
             angular = True
 
-        rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
+        rng_state = random_state.randint(
+            INT32_MIN, INT32_MAX, 3
+        ).astype(np.int64)
 
         if scipy.sparse.isspmatrix_csr(X):
             if metric in sparse.sparse_named_distances:
-                distance_func = sparse.sparse_named_distances[metric]
+                distance_func = sparse.sparse_named_distances[
+                    metric
+                ]
                 if metric in sparse.sparse_need_n_features:
                     metric_kwds["n_features"] = X.shape[1]
             else:
                 raise ValueError(
-                    "Metric {} not supported for sparse " + "data".format(metric)
+                    "Metric {} not supported for sparse "
+                    + "data".format(metric)
                 )
             metric_nn_descent = sparse.make_sparse_nn_descent(
                 distance_func, tuple(metric_kwds.values())
             )
 
             # TODO: Hacked values for now
-            n_trees = 5 + int(round((X.shape[0]) ** 0.5 / 20.0))
-            n_iters = max(5, int(round(np.log2(X.shape[0]))))
+            n_trees = 5 + int(
+                round((X.shape[0]) ** 0.5 / 20.0)
+            )
+            n_iters = max(
+                5, int(round(np.log2(X.shape[0])))
+            )
             if verbose:
-                print(ts(), "Building RP forest with", str(n_trees), "trees")
+                print(
+                    ts(),
+                    "Building RP forest with",
+                    str(n_trees),
+                    "trees",
+                )
 
-            rp_forest = make_forest(X, n_neighbors, n_trees, rng_state, angular)
+            rp_forest = make_forest(
+                X, n_neighbors, n_trees, rng_state, angular
+            )
             leaf_array = rptree_leaf_array(rp_forest)
 
             if verbose:
-                print(ts(), "NN descent for", str(n_iters), "iterations")
+                print(
+                    ts(),
+                    "NN descent for",
+                    str(n_iters),
+                    "iterations",
+                )
             knn_indices, knn_dists = metric_nn_descent(
                 X.indices,
                 X.indptr,
@@ -267,15 +321,31 @@ def nearest_neighbors(
                 distance_func, tuple(metric_kwds.values())
             )
             # TODO: Hacked values for now
-            n_trees = 5 + int(round((X.shape[0]) ** 0.5 / 20.0))
-            n_iters = max(5, int(round(np.log2(X.shape[0]))))
+            n_trees = 5 + int(
+                round((X.shape[0]) ** 0.5 / 20.0)
+            )
+            n_iters = max(
+                5, int(round(np.log2(X.shape[0])))
+            )
 
             if verbose:
-                print(ts(), "Building RP forest with", str(n_trees), "trees")
-            rp_forest = make_forest(X, n_neighbors, n_trees, rng_state, angular)
+                print(
+                    ts(),
+                    "Building RP forest with",
+                    str(n_trees),
+                    "trees",
+                )
+            rp_forest = make_forest(
+                X, n_neighbors, n_trees, rng_state, angular
+            )
             leaf_array = rptree_leaf_array(rp_forest)
             if verbose:
-                print(ts(), "NN descent for", str(n_iters), "iterations")
+                print(
+                    ts(),
+                    "NN descent for",
+                    str(n_iters),
+                    "iterations",
+                )
             knn_indices, knn_dists = metric_nn_descent(
                 X,
                 n_neighbors,
@@ -299,7 +369,9 @@ def nearest_neighbors(
 
 
 @numba.njit(parallel=True, fastmath=True)
-def compute_membership_strengths(knn_indices, knn_dists, sigmas, rhos):
+def compute_membership_strengths(
+    knn_indices, knn_dists, sigmas, rhos
+):
     """Construct the membership strength data for the 1-skeleton of each local
     fuzzy simplicial set -- this is formed as a sparse matrix where each row is
     a local fuzzy simplicial set, with a membership strength for the
@@ -333,9 +405,15 @@ def compute_membership_strengths(knn_indices, knn_dists, sigmas, rhos):
     n_samples = knn_indices.shape[0]
     n_neighbors = knn_indices.shape[1]
 
-    rows = np.zeros((n_samples * n_neighbors), dtype=np.int64)
-    cols = np.zeros((n_samples * n_neighbors), dtype=np.int64)
-    vals = np.zeros((n_samples * n_neighbors), dtype=np.float64)
+    rows = np.zeros(
+        (n_samples * n_neighbors), dtype=np.int64
+    )
+    cols = np.zeros(
+        (n_samples * n_neighbors), dtype=np.int64
+    )
+    vals = np.zeros(
+        (n_samples * n_neighbors), dtype=np.float64
+    )
 
     for i in range(n_samples):
         for j in range(n_neighbors):
@@ -346,7 +424,12 @@ def compute_membership_strengths(knn_indices, knn_dists, sigmas, rhos):
             elif knn_dists[i, j] - rhos[i] <= 0.0:
                 val = 1.0
             else:
-                val = np.exp(-((knn_dists[i, j] - rhos[i]) / (sigmas[i])))
+                val = np.exp(
+                    -(
+                        (knn_dists[i, j] - rhos[i])
+                        / (sigmas[i])
+                    )
+                )
 
             rows[i * n_neighbors + j] = i
             cols[i * n_neighbors + j] = knn_indices[i, j]
@@ -473,11 +556,19 @@ def fuzzy_simplicial_set(
     """
     if knn_indices is None or knn_dists is None:
         knn_indices, knn_dists, _ = nearest_neighbors(
-            X, n_neighbors, metric, metric_kwds, angular, random_state, verbose=verbose
+            X,
+            n_neighbors,
+            metric,
+            metric_kwds,
+            angular,
+            random_state,
+            verbose=verbose,
         )
 
     sigmas, rhos = smooth_knn_dist(
-        knn_dists, n_neighbors, local_connectivity=local_connectivity
+        knn_dists,
+        n_neighbors,
+        local_connectivity=local_connectivity,
     )
 
     rows, cols, vals = compute_membership_strengths(
@@ -494,7 +585,8 @@ def fuzzy_simplicial_set(
     prod_matrix = result.multiply(transpose)
 
     result = (
-        set_op_mix_ratio * (result + transpose - prod_matrix)
+        set_op_mix_ratio
+        * (result + transpose - prod_matrix)
         + (1.0 - set_op_mix_ratio) * prod_matrix
     )
 
@@ -504,7 +596,14 @@ def fuzzy_simplicial_set(
 
 
 @numba.njit()
-def fast_intersection(rows, cols, values, target, unknown_dist=1.0, far_dist=5.0):
+def fast_intersection(
+    rows,
+    cols,
+    values,
+    target,
+    unknown_dist=1.0,
+    far_dist=5.0,
+):
     """Under the assumption of categorical distance for the intersecting
     simplicial set perform a fast intersection.
 
@@ -567,7 +666,9 @@ def reset_local_connectivity(simplicial_set):
     simplicial_set = normalize(simplicial_set, norm="max")
     transpose = simplicial_set.transpose()
     prod_matrix = simplicial_set.multiply(transpose)
-    simplicial_set = simplicial_set + transpose - prod_matrix
+    simplicial_set = (
+        simplicial_set + transpose - prod_matrix
+    )
     simplicial_set.eliminate_zeros()
 
     return simplicial_set
@@ -618,7 +719,9 @@ def categorical_simplicial_set_intersection(
     return reset_local_connectivity(simplicial_set)
 
 
-def general_simplicial_set_intersection(simplicial_set1, simplicial_set2, weight):
+def general_simplicial_set_intersection(
+    simplicial_set1, simplicial_set2, weight
+):
 
     result = (simplicial_set1 + simplicial_set2).tocoo()
     left = simplicial_set1.tocsr()
@@ -656,9 +759,13 @@ def make_epochs_per_sample(weights, n_epochs):
     -------
     An array of number of epochs per sample, one for each 1-simplex.
     """
-    result = -1.0 * np.ones(weights.shape[0], dtype=np.float64)
+    result = -1.0 * np.ones(
+        weights.shape[0], dtype=np.float64
+    )
     n_samples = n_epochs * (weights / weights.max())
-    result[n_samples > 0] = float(n_epochs) / n_samples[n_samples > 0]
+    result[n_samples > 0] = (
+        float(n_epochs) / n_samples[n_samples > 0]
+    )
     return result
 
 
@@ -782,11 +889,17 @@ def optimize_layout(
     """
 
     dim = head_embedding.shape[1]
-    move_other = head_embedding.shape[0] == tail_embedding.shape[0]
+    move_other = (
+        head_embedding.shape[0] == tail_embedding.shape[0]
+    )
     alpha = initial_alpha
 
-    epochs_per_negative_sample = epochs_per_sample / negative_sample_rate
-    epoch_of_next_negative_sample = epochs_per_negative_sample.copy()
+    epochs_per_negative_sample = (
+        epochs_per_sample / negative_sample_rate
+    )
+    epoch_of_next_negative_sample = (
+        epochs_per_negative_sample.copy()
+    )
     epoch_of_next_sample = epochs_per_sample.copy()
 
     for n in range(n_epochs):
@@ -801,18 +914,29 @@ def optimize_layout(
                 dist_squared = rdist(current, other)
 
                 if dist_squared > 0.0:
-                    grad_coeff = -2.0 * a * b * pow(dist_squared, b - 1.0)
-                    grad_coeff /= a * pow(dist_squared, b) + 1.0
+                    grad_coeff = (
+                        -2.0
+                        * a
+                        * b
+                        * pow(dist_squared, b - 1.0)
+                    )
+                    grad_coeff /= (
+                        a * pow(dist_squared, b) + 1.0
+                    )
                 else:
                     grad_coeff = 0.0
 
                 for d in range(dim):
-                    grad_d = clip(grad_coeff * (current[d] - other[d]))
+                    grad_d = clip(
+                        grad_coeff * (current[d] - other[d])
+                    )
                     current[d] += grad_d * alpha
                     if move_other:
                         other[d] += -grad_d * alpha
 
-                epoch_of_next_sample[i] += epochs_per_sample[i]
+                epoch_of_next_sample[
+                    i
+                ] += epochs_per_sample[i]
 
                 n_neg_samples = int(
                     (n - epoch_of_next_negative_sample[i])
@@ -828,9 +952,9 @@ def optimize_layout(
 
                     if dist_squared > 0.0:
                         grad_coeff = 2.0 * gamma * b
-                        grad_coeff /= (0.001 + dist_squared) * (
-                            a * pow(dist_squared, b) + 1
-                        )
+                        grad_coeff /= (
+                            0.001 + dist_squared
+                        ) * (a * pow(dist_squared, b) + 1)
                     elif j == k:
                         continue
                     else:
@@ -838,19 +962,27 @@ def optimize_layout(
 
                     for d in range(dim):
                         if grad_coeff > 0.0:
-                            grad_d = clip(grad_coeff * (current[d] - other[d]))
+                            grad_d = clip(
+                                grad_coeff
+                                * (current[d] - other[d])
+                            )
                         else:
                             grad_d = 4.0
                         current[d] += grad_d * alpha
 
                 epoch_of_next_negative_sample[i] += (
-                    n_neg_samples * epochs_per_negative_sample[i]
+                    n_neg_samples
+                    * epochs_per_negative_sample[i]
                 )
 
-        alpha = initial_alpha * (1.0 - (float(n) / float(n_epochs)))
+        alpha = initial_alpha * (
+            1.0 - (float(n) / float(n_epochs))
+        )
 
         if verbose and n % int(n_epochs / 10) == 0:
-            print("\tcompleted ", n, " / ", n_epochs, "epochs")
+            print(
+                "\tcompleted ", n, " / ", n_epochs, "epochs"
+            )
 
     return head_embedding
 
@@ -950,12 +1082,16 @@ def simplicial_set_embedding(
         else:
             n_epochs = 200
 
-    graph.data[graph.data < (graph.data.max() / float(n_epochs))] = 0.0
+    graph.data[
+        graph.data < (graph.data.max() / float(n_epochs))
+    ] = 0.0
     graph.eliminate_zeros()
 
     if isinstance(init, str) and init == "random":
         embedding = random_state.uniform(
-            low=-10.0, high=10.0, size=(graph.shape[0], n_components)
+            low=-10.0,
+            high=10.0,
+            size=(graph.shape[0], n_components),
         ).astype(np.float32)
     elif isinstance(init, str) and init == "spectral":
         # We add a little noise to avoid local minima for optimization to come
@@ -971,29 +1107,38 @@ def simplicial_set_embedding(
         embedding = (initialisation * expansion).astype(
             np.float32
         ) + random_state.normal(
-            scale=0.0001, size=[graph.shape[0], n_components]
+            scale=0.0001,
+            size=[graph.shape[0], n_components],
         ).astype(
             np.float32
         )
     else:
         init_data = np.array(init)
         if len(init_data.shape) == 2:
-            if np.unique(init_data, axis=0).shape[0] < init_data.shape[0]:
+            if (
+                np.unique(init_data, axis=0).shape[0]
+                < init_data.shape[0]
+            ):
                 tree = KDTree(init_data)
                 dist, ind = tree.query(init_data, k=2)
                 nndist = np.mean(dist[:, 1])
                 embedding = init_data + random_state.normal(
-                    scale=0.001 * nndist, size=init_data.shape
+                    scale=0.001 * nndist,
+                    size=init_data.shape,
                 ).astype(np.float32)
             else:
                 embedding = init_data
 
-    epochs_per_sample = make_epochs_per_sample(graph.data, n_epochs)
+    epochs_per_sample = make_epochs_per_sample(
+        graph.data, n_epochs
+    )
 
     head = graph.row
     tail = graph.col
 
-    rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
+    rng_state = random_state.randint(
+        INT32_MIN, INT32_MAX, 3
+    ).astype(np.int64)
     embedding = optimize_layout(
         embedding,
         embedding,
@@ -1037,12 +1182,18 @@ def init_transform(indices, weights, embedding):
     new_embedding: array of shape (n_new_samples, dim)
         An initial embedding of the new sample points.
     """
-    result = np.zeros((indices.shape[0], embedding.shape[1]), dtype=np.float32)
+    result = np.zeros(
+        (indices.shape[0], embedding.shape[1]),
+        dtype=np.float32,
+    )
 
     for i in range(indices.shape[0]):
         for j in range(indices.shape[1]):
             for d in range(embedding.shape[1]):
-                result[i, d] += weights[i, j] * embedding[indices[i, j], d]
+                result[i, d] += (
+                    weights[i, j]
+                    * embedding[indices[i, j], d]
+                )
 
     return result
 
@@ -1060,7 +1211,9 @@ def find_ab_params(spread, min_dist):
     xv = np.linspace(0, spread * 3, 300)
     yv = np.zeros(xv.shape)
     yv[xv < min_dist] = 1.0
-    yv[xv >= min_dist] = np.exp(-(xv[xv >= min_dist] - min_dist) / spread)
+    yv[xv >= min_dist] = np.exp(
+        -(xv[xv >= min_dist] - min_dist) / spread
+    )
     params, covar = curve_fit(curve, xv, yv)
     return params[0], params[1]
 
@@ -1289,41 +1442,84 @@ class UMAP(BaseEstimator):
         self.b = b
 
     def _validate_parameters(self):
-        if self.set_op_mix_ratio < 0.0 or self.set_op_mix_ratio > 1.0:
-            raise ValueError("set_op_mix_ratio must be between 0.0 and 1.0")
+        if (
+            self.set_op_mix_ratio < 0.0
+            or self.set_op_mix_ratio > 1.0
+        ):
+            raise ValueError(
+                "set_op_mix_ratio must be between 0.0 and 1.0"
+            )
         if self.repulsion_strength < 0.0:
-            raise ValueError("repulsion_strength cannot be negative")
+            raise ValueError(
+                "repulsion_strength cannot be negative"
+            )
         if self.min_dist > self.spread:
-            raise ValueError("min_dist must be less than or equal to spread")
+            raise ValueError(
+                "min_dist must be less than or equal to spread"
+            )
         if self.min_dist < 0.0:
-            raise ValueError("min_dist must be greater than 0.0")
-        if not isinstance(self.init, str) and not isinstance(self.init, np.ndarray):
-            raise ValueError("init must be a string or ndarray")
-        if isinstance(self.init, str) and self.init not in ("spectral", "random"):
-            raise ValueError('string init values must be "spectral" or "random"')
+            raise ValueError(
+                "min_dist must be greater than 0.0"
+            )
+        if not isinstance(
+            self.init, str
+        ) and not isinstance(self.init, np.ndarray):
+            raise ValueError(
+                "init must be a string or ndarray"
+            )
+        if isinstance(self.init, str) and self.init not in (
+            "spectral",
+            "random",
+        ):
+            raise ValueError(
+                'string init values must be "spectral" or "random"'
+            )
         if (
             isinstance(self.init, np.ndarray)
             and self.init.shape[1] != self.n_components
         ):
-            raise ValueError("init ndarray must match n_components value")
-        if not isinstance(self.metric, str) and not callable(self.metric):
-            raise ValueError("metric must be string or callable")
+            raise ValueError(
+                "init ndarray must match n_components value"
+            )
+        if not isinstance(
+            self.metric, str
+        ) and not callable(self.metric):
+            raise ValueError(
+                "metric must be string or callable"
+            )
         if self.negative_sample_rate < 0:
-            raise ValueError("negative sample rate must be positive")
+            raise ValueError(
+                "negative sample rate must be positive"
+            )
         if self._initial_alpha < 0.0:
-            raise ValueError("learning_rate must be positive")
+            raise ValueError(
+                "learning_rate must be positive"
+            )
         if self.n_neighbors < 2:
-            raise ValueError("n_neighbors must be greater than 2")
-        if self.target_n_neighbors < 2 and self.target_n_neighbors != -1:
-            raise ValueError("target_n_neighbors must be greater than 2")
+            raise ValueError(
+                "n_neighbors must be greater than 2"
+            )
+        if (
+            self.target_n_neighbors < 2
+            and self.target_n_neighbors != -1
+        ):
+            raise ValueError(
+                "target_n_neighbors must be greater than 2"
+            )
         if not isinstance(self.n_components, int):
             raise ValueError("n_components must be an int")
         if self.n_components < 1:
-            raise ValueError("n_components must be greater than 0")
+            raise ValueError(
+                "n_components must be greater than 0"
+            )
         if self.n_epochs is not None and (
-            self.n_epochs <= 10 or not isinstance(self.n_epochs, int)
+            self.n_epochs <= 10
+            or not isinstance(self.n_epochs, int)
         ):
-            raise ValueError("n_epochs must be a positive integer " "larger than 10")
+            raise ValueError(
+                "n_epochs must be a positive integer "
+                "larger than 10"
+            )
 
     def fit(self, X, y=None):
         """Fit X into an embedded space.
@@ -1345,12 +1541,16 @@ class UMAP(BaseEstimator):
             ``target_metric_kwds``.
         """
 
-        X = check_array(X, dtype=np.float32, accept_sparse="csr")
+        X = check_array(
+            X, dtype=np.float32, accept_sparse="csr"
+        )
         self._raw_data = X
 
         # Handle all the optional arguments, setting default
         if self.a is None or self.b is None:
-            self._a, self._b = find_ab_params(self.spread, self.min_dist)
+            self._a, self._b = find_ab_params(
+                self.spread, self.min_dist
+            )
         else:
             self._a = self.a
             self._b = self.b
@@ -1361,12 +1561,18 @@ class UMAP(BaseEstimator):
             self._metric_kwds = {}
 
         if self.target_metric_kwds is not None:
-            self._target_metric_kwds = self.target_metric_kwds
+            self._target_metric_kwds = (
+                self.target_metric_kwds
+            )
         else:
             self._target_metric_kwds = {}
 
         if isinstance(self.init, np.ndarray):
-            init = check_array(self.init, dtype=np.float32, accept_sparse=False)
+            init = check_array(
+                self.init,
+                dtype=np.float32,
+                accept_sparse=False,
+            )
         else:
             init = self.init
 
@@ -1408,7 +1614,9 @@ class UMAP(BaseEstimator):
         # Handle small cases efficiently by computing all distances
         if X.shape[0] < 4096:
             self._small_data = True
-            dmat = pairwise_distances(X, metric=self.metric, **self._metric_kwds)
+            dmat = pairwise_distances(
+                X, metric=self.metric, **self._metric_kwds
+            )
             self.graph_ = fuzzy_simplicial_set(
                 dmat,
                 self._n_neighbors,
@@ -1425,7 +1633,11 @@ class UMAP(BaseEstimator):
         else:
             self._small_data = False
             # Standard case
-            (self._knn_indices, self._knn_dists, self._rp_forest) = nearest_neighbors(
+            (
+                self._knn_indices,
+                self._knn_dists,
+                self._rp_forest,
+            ) = nearest_neighbors(
                 X,
                 self._n_neighbors,
                 self.metric,
@@ -1453,7 +1665,9 @@ class UMAP(BaseEstimator):
                 (X.shape[0], X.shape[0]), dtype=np.int8
             )
             self._search_graph.rows = self._knn_indices
-            self._search_graph.data = (self._knn_dists != 0).astype(np.int8)
+            self._search_graph.data = (
+                self._knn_dists != 0
+            ).astype(np.int8)
             self._search_graph = self._search_graph.maximum(
                 self._search_graph.transpose()
             ).tocsr()
@@ -1461,18 +1675,23 @@ class UMAP(BaseEstimator):
             if callable(self.metric):
                 self._distance_func = self.metric
             elif self.metric in dist.named_distances:
-                self._distance_func = dist.named_distances[self.metric]
+                self._distance_func = dist.named_distances[
+                    self.metric
+                ]
             elif self.metric == "precomputed":
                 warn(
                     "Using precomputed metric; transform will be unavailable for new data"
                 )
             else:
                 raise ValueError(
-                    "Metric is neither callable, " + "nor a recognised string"
+                    "Metric is neither callable, "
+                    + "nor a recognised string"
                 )
 
             if self.metric != "precomputed":
-                self._dist_args = tuple(self._metric_kwds.values())
+                self._dist_args = tuple(
+                    self._metric_kwds.values()
+                )
 
                 self._random_init, self._tree_init = make_initialisations(
                     self._distance_func, self._dist_args
@@ -1491,7 +1710,9 @@ class UMAP(BaseEstimator):
             y_ = check_array(y, ensure_2d=False)
             if self.target_metric == "categorical":
                 if self.target_weight < 1.0:
-                    far_dist = 2.5 * (1.0 / (1.0 - self.target_weight))
+                    far_dist = 2.5 * (
+                        1.0 / (1.0 - self.target_weight)
+                    )
                 else:
                     far_dist = 1.0e12
                 self.graph_ = categorical_simplicial_set_intersection(
@@ -1501,7 +1722,9 @@ class UMAP(BaseEstimator):
                 if self.target_n_neighbors == -1:
                     target_n_neighbors = self._n_neighbors
                 else:
-                    target_n_neighbors = self.target_n_neighbors
+                    target_n_neighbors = (
+                        self.target_n_neighbors
+                    )
 
                 # Handle the small case as precomputed as before
                 if y.shape[0] < 4096:
@@ -1544,9 +1767,13 @@ class UMAP(BaseEstimator):
                 # #                                        product)
                 # self.graph_ = product
                 self.graph_ = general_simplicial_set_intersection(
-                    self.graph_, target_graph, self.target_weight
+                    self.graph_,
+                    target_graph,
+                    self.target_weight,
                 )
-                self.graph_ = reset_local_connectivity(self.graph_)
+                self.graph_ = reset_local_connectivity(
+                    self.graph_
+                )
 
         if self.n_epochs is None:
             n_epochs = 0
@@ -1625,37 +1852,62 @@ class UMAP(BaseEstimator):
                 "only a single data sample."
             )
         # If we just have the original input then short circuit things
-        X = check_array(X, dtype=np.float32, accept_sparse="csr")
+        X = check_array(
+            X, dtype=np.float32, accept_sparse="csr"
+        )
         x_hash = joblib.hash(X)
         if x_hash == self._input_hash:
             return self.embedding_
 
         if self._sparse_data:
-            raise ValueError("Transform not available for sparse input.")
+            raise ValueError(
+                "Transform not available for sparse input."
+            )
         elif self.metric == "precomputed":
             raise ValueError(
-                "Transform  of new data not available for " "precomputed metric."
+                "Transform  of new data not available for "
+                "precomputed metric."
             )
 
         X = check_array(X, dtype=np.float32, order="C")
-        random_state = check_random_state(self.transform_seed)
-        rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
+        random_state = check_random_state(
+            self.transform_seed
+        )
+        rng_state = random_state.randint(
+            INT32_MIN, INT32_MAX, 3
+        ).astype(np.int64)
 
         if self._small_data:
             dmat = pairwise_distances(
-                X, self._raw_data, metric=self.metric, **self._metric_kwds
+                X,
+                self._raw_data,
+                metric=self.metric,
+                **self._metric_kwds
             )
-            indices = np.argpartition(dmat, self._n_neighbors)[:, : self._n_neighbors]
-            dmat_shortened = submatrix(dmat, indices, self._n_neighbors)
+            indices = np.argpartition(
+                dmat, self._n_neighbors
+            )[:, : self._n_neighbors]
+            dmat_shortened = submatrix(
+                dmat, indices, self._n_neighbors
+            )
             indices_sorted = np.argsort(dmat_shortened)
-            indices = submatrix(indices, indices_sorted, self._n_neighbors)
-            dists = submatrix(dmat_shortened, indices_sorted, self._n_neighbors)
+            indices = submatrix(
+                indices, indices_sorted, self._n_neighbors
+            )
+            dists = submatrix(
+                dmat_shortened,
+                indices_sorted,
+                self._n_neighbors,
+            )
         else:
             init = initialise_search(
                 self._rp_forest,
                 self._raw_data,
                 X,
-                int(self._n_neighbors * self.transform_queue_size),
+                int(
+                    self._n_neighbors
+                    * self.transform_queue_size
+                ),
                 self._random_init,
                 self._tree_init,
                 rng_state,
@@ -1672,24 +1924,37 @@ class UMAP(BaseEstimator):
             indices = indices[:, : self._n_neighbors]
             dists = dists[:, : self._n_neighbors]
 
-        adjusted_local_connectivity = max(0, self.local_connectivity - 1.0)
+        adjusted_local_connectivity = max(
+            0, self.local_connectivity - 1.0
+        )
         sigmas, rhos = smooth_knn_dist(
-            dists, self._n_neighbors, local_connectivity=adjusted_local_connectivity
+            dists,
+            self._n_neighbors,
+            local_connectivity=adjusted_local_connectivity,
         )
 
-        rows, cols, vals = compute_membership_strengths(indices, dists, sigmas, rhos)
+        rows, cols, vals = compute_membership_strengths(
+            indices, dists, sigmas, rhos
+        )
 
         graph = scipy.sparse.coo_matrix(
-            (vals, (rows, cols)), shape=(X.shape[0], self._raw_data.shape[0])
+            (vals, (rows, cols)),
+            shape=(X.shape[0], self._raw_data.shape[0]),
         )
 
         # This was a very specially constructed graph with constant degree.
         # That lets us do fancy unpacking by reshaping the csr matrix indices
         # and data. Doing so relies on the constant degree assumption!
         csr_graph = normalize(graph.tocsr(), norm="l1")
-        inds = csr_graph.indices.reshape(X.shape[0], self._n_neighbors)
-        weights = csr_graph.data.reshape(X.shape[0], self._n_neighbors)
-        embedding = init_transform(inds, weights, self.embedding_)
+        inds = csr_graph.indices.reshape(
+            X.shape[0], self._n_neighbors
+        )
+        weights = csr_graph.data.reshape(
+            X.shape[0], self._n_neighbors
+        )
+        embedding = init_transform(
+            inds, weights, self.embedding_
+        )
 
         if self.n_epochs is None:
             # For smaller datasets we can use more epochs
@@ -1700,17 +1965,24 @@ class UMAP(BaseEstimator):
         else:
             n_epochs = self.n_epochs // 3.0
 
-        graph.data[graph.data < (graph.data.max() / float(n_epochs))] = 0.0
+        graph.data[
+            graph.data
+            < (graph.data.max() / float(n_epochs))
+        ] = 0.0
         graph.eliminate_zeros()
 
-        epochs_per_sample = make_epochs_per_sample(graph.data, n_epochs)
+        epochs_per_sample = make_epochs_per_sample(
+            graph.data, n_epochs
+        )
 
         head = graph.row
         tail = graph.col
 
         embedding = optimize_layout(
             embedding,
-            self.embedding_.astype(np.float32, copy=False),  # Fix #179
+            self.embedding_.astype(
+                np.float32, copy=False
+            ),  # Fix #179
             head,
             tail,
             n_epochs,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -27,7 +27,13 @@ import umap.distances as dist
 
 import umap.sparse as sparse
 
-from umap.utils import tau_rand_int, deheap_sort, submatrix, ts
+from umap.utils import (
+    tau_rand_int,
+    deheap_sort,
+    submatrix,
+    ts,
+    fast_knn_indices
+)
 from umap.rp_tree import rptree_leaf_array, make_forest
 from umap.nndescent import (
     make_nn_descent,
@@ -200,7 +206,7 @@ def nearest_neighbors(
     if metric == "precomputed":
         # Note that this does not support sparse distance matrices yet ...
         # Compute indices of n nearest neighbors
-        knn_indices = np.argsort(X)[:, :n_neighbors]
+        knn_indices = fast_knn_indices(X, n_neighbors)
         # Compute the nearest neighbor distances
         #   (equivalent to np.sort(X)[:,:n_neighbors])
         knn_dists = X[np.arange(X.shape[0])[:, None], knn_indices].copy()

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -32,7 +32,7 @@ from umap.utils import (
     deheap_sort,
     submatrix,
     ts,
-    fast_knn_indices
+    fast_knn_indices,
 )
 from umap.rp_tree import rptree_leaf_array, make_forest
 from umap.nndescent import (

--- a/umap/utils.py
+++ b/umap/utils.py
@@ -25,9 +25,11 @@ def fast_knn_indices(X, n_neighbors):
     knn_indices: array of shape (n_samples, n_neighbors)
         The indices on the ``n_neighbors`` closest points in the dataset.
     """
-    knn_indices = np.empty((X.shape[0], n_neighbors), dtype=np.int32)
+    knn_indices = np.empty(
+        (X.shape[0], n_neighbors), dtype=np.int32
+    )
     for row in numba.prange(X.shape[0]):
-        v = X[row].argsort(kind='quicksort')
+        v = X[row].argsort(kind="quicksort")
         v = v[:n_neighbors]
         knn_indices[row] = v
     return knn_indices
@@ -46,15 +48,15 @@ def tau_rand_int(state):
     -------
     A (pseudo)-random int32 value
     """
-    state[0] = (((state[0] & 4294967294) << 12) & 0xFFFFFFFF) ^ (
-        (((state[0] << 13) & 0xFFFFFFFF) ^ state[0]) >> 19
-    )
-    state[1] = (((state[1] & 4294967288) << 4) & 0xFFFFFFFF) ^ (
-        (((state[1] << 2) & 0xFFFFFFFF) ^ state[1]) >> 25
-    )
-    state[2] = (((state[2] & 4294967280) << 17) & 0xFFFFFFFF) ^ (
-        (((state[2] << 3) & 0xFFFFFFFF) ^ state[2]) >> 11
-    )
+    state[0] = (
+        ((state[0] & 4294967294) << 12) & 0xFFFFFFFF
+    ) ^ ((((state[0] << 13) & 0xFFFFFFFF) ^ state[0]) >> 19)
+    state[1] = (
+        ((state[1] & 4294967288) << 4) & 0xFFFFFFFF
+    ) ^ ((((state[1] << 2) & 0xFFFFFFFF) ^ state[1]) >> 25)
+    state[2] = (
+        ((state[2] & 4294967280) << 17) & 0xFFFFFFFF
+    ) ^ ((((state[2] << 3) & 0xFFFFFFFF) ^ state[2]) >> 11)
 
     return state[0] ^ state[1] ^ state[2]
 
@@ -153,7 +155,9 @@ def make_heap(n_points, size):
     -------
     heap: An ndarray suitable for passing to other numba enabled heap functions.
     """
-    result = np.zeros((3, int(n_points), int(size)), dtype=np.float64)
+    result = np.zeros(
+        (3, int(n_points), int(size)), dtype=np.float64
+    )
     result[0] = -1
     result[1] = np.infty
     result[2] = 0
@@ -336,14 +340,23 @@ def siftdown(heap1, heap2, elt):
         if heap1[swap] < heap1[left_child]:
             swap = left_child
 
-        if right_child < heap1.shape[0] and heap1[swap] < heap1[right_child]:
+        if (
+            right_child < heap1.shape[0]
+            and heap1[swap] < heap1[right_child]
+        ):
             swap = right_child
 
         if swap == elt:
             break
         else:
-            heap1[elt], heap1[swap] = heap1[swap], heap1[elt]
-            heap2[elt], heap2[swap] = heap2[swap], heap2[elt]
+            heap1[elt], heap1[swap] = (
+                heap1[swap],
+                heap1[elt],
+            )
+            heap2[elt], heap2[swap] = (
+                heap2[swap],
+                heap2[elt],
+            )
             elt = swap
 
 
@@ -373,11 +386,15 @@ def deheap_sort(heap):
         dist_heap = weights[i]
 
         for j in range(ind_heap.shape[0] - 1):
-            ind_heap[0], ind_heap[ind_heap.shape[0] - j - 1] = (
+            ind_heap[0], ind_heap[
+                ind_heap.shape[0] - j - 1
+            ] = (
                 ind_heap[ind_heap.shape[0] - j - 1],
                 ind_heap[0],
             )
-            dist_heap[0], dist_heap[dist_heap.shape[0] - j - 1] = (
+            dist_heap[0], dist_heap[
+                dist_heap.shape[0] - j - 1
+            ] = (
                 dist_heap[dist_heap.shape[0] - j - 1],
                 dist_heap[0],
             )
@@ -431,7 +448,13 @@ def smallest_flagged(heap, row):
 
 
 @numba.njit(parallel=True)
-def build_candidates(current_graph, n_vertices, n_neighbors, max_candidates, rng_state):
+def build_candidates(
+    current_graph,
+    n_vertices,
+    n_neighbors,
+    max_candidates,
+    rng_state,
+):
     """Build a heap of candidate neighbors for nearest neighbor descent. For
     each vertex the candidate neighbors are any current neighbors, and any
     vertices that have the vertex as one of their nearest neighbors.
@@ -458,7 +481,9 @@ def build_candidates(current_graph, n_vertices, n_neighbors, max_candidates, rng
     candidate_neighbors: A heap with an array of (randomly sorted) candidate
     neighbors for each vertex in the graph.
     """
-    candidate_neighbors = make_heap(n_vertices, max_candidates)
+    candidate_neighbors = make_heap(
+        n_vertices, max_candidates
+    )
     for i in range(n_vertices):
         for j in range(n_neighbors):
             if current_graph[0, i, j] < 0:
@@ -475,7 +500,12 @@ def build_candidates(current_graph, n_vertices, n_neighbors, max_candidates, rng
 
 @numba.njit(parallel=True)
 def new_build_candidates(
-    current_graph, n_vertices, n_neighbors, max_candidates, rng_state, rho=0.5
+    current_graph,
+    n_vertices,
+    n_neighbors,
+    max_candidates,
+    rng_state,
+    rho=0.5,
 ):  # pragma: no cover
     """Build a heap of candidate neighbors for nearest neighbor descent. For
     each vertex the candidate neighbors are any current neighbors, and any
@@ -503,8 +533,12 @@ def new_build_candidates(
     candidate_neighbors: A heap with an array of (randomly sorted) candidate
     neighbors for each vertex in the graph.
     """
-    new_candidate_neighbors = make_heap(n_vertices, max_candidates)
-    old_candidate_neighbors = make_heap(n_vertices, max_candidates)
+    new_candidate_neighbors = make_heap(
+        n_vertices, max_candidates
+    )
+    old_candidate_neighbors = make_heap(
+        n_vertices, max_candidates
+    )
 
     for i in numba.prange(n_vertices):
         for j in range(n_neighbors):
@@ -516,11 +550,35 @@ def new_build_candidates(
             if tau_rand(rng_state) < rho:
                 c = 0
                 if isn:
-                    c += heap_push(new_candidate_neighbors, i, d, idx, isn)
-                    c += heap_push(new_candidate_neighbors, idx, d, i, isn)
+                    c += heap_push(
+                        new_candidate_neighbors,
+                        i,
+                        d,
+                        idx,
+                        isn,
+                    )
+                    c += heap_push(
+                        new_candidate_neighbors,
+                        idx,
+                        d,
+                        i,
+                        isn,
+                    )
                 else:
-                    heap_push(old_candidate_neighbors, i, d, idx, isn)
-                    heap_push(old_candidate_neighbors, idx, d, i, isn)
+                    heap_push(
+                        old_candidate_neighbors,
+                        i,
+                        d,
+                        idx,
+                        isn,
+                    )
+                    heap_push(
+                        old_candidate_neighbors,
+                        idx,
+                        d,
+                        i,
+                        isn,
+                    )
 
                 if c > 0:
                     current_graph[2, i, j] = 0
@@ -549,7 +607,9 @@ def submatrix(dmat, indices_col, n_neighbors):
         The corresponding submatrix.
     """
     n_samples_transform, n_samples_fit = dmat.shape
-    submat = np.zeros((n_samples_transform, n_neighbors), dtype=dmat.dtype)
+    submat = np.zeros(
+        (n_samples_transform, n_neighbors), dtype=dmat.dtype
+    )
     for i in numba.prange(n_samples_transform):
         for j in numba.prange(n_neighbors):
             submat[i, j] = dmat[i, indices_col[i, j]]

--- a/umap/utils.py
+++ b/umap/utils.py
@@ -8,6 +8,31 @@ import numpy as np
 import numba
 
 
+@numba.njit(parallel=True)
+def fast_knn_indices(X, n_neighbors):
+    """A fast computation of knn indices.
+
+    Parameters
+    ----------
+    X: array of shape (n_samples, n_features)
+        The input data to compute the k-neighbor indices of.
+
+    n_neighbors: int
+        The number of nearest neighbors to compute for each sample in ``X``.
+
+    Returns
+    -------
+    knn_indices: array of shape (n_samples, n_neighbors)
+        The indices on the ``n_neighbors`` closest points in the dataset.
+    """
+    knn_indices = np.empty((X.shape[0], n_neighbors), dtype=np.int32)
+    for row in numba.prange(X.shape[0]):
+        v = X[row].argsort(kind='quicksort')
+        v = v[:n_neighbors]
+        knn_indices[row] = v
+    return knn_indices
+
+
 @numba.njit("i4(i8[:])")
 def tau_rand_int(state):
     """A fast (pseudo)-random number generator.


### PR DESCRIPTION
Tested on a `[50k, 50k]` distance matrix computed on 50k `np.random.normal` points where this runs in 6.8s-7.0s on a 120 core machine whereas the old code takes 245s.