### PR TITLE
Fix #217

### DIFF
--- a/umap/tests/test_umap.py
+++ b/umap/tests/test_umap.py
@@ -950,15 +950,16 @@ def test_umap_fit_params():
     res = u.fit(x)
     assert isinstance(res, UMAP)
 
+
 def test_umap_transform_embedding_stability():
     """Test that transforming data does not alter the learned embeddings
-    
+
     Issue #217 describes how using transform to embed new data using a
     trained UMAP transformer causes the fitting embedding matrix to change
     in cases when the new data has the same number of rows as the original
     training data.
     """
-    
+
     data = iris.data[iris_selection]
     fitter = UMAP(n_neighbors=10, min_dist=0.01, random_state=42).fit(data)
     original_embedding = fitter.embedding_.copy()
@@ -971,7 +972,7 @@ def test_umap_transform_embedding_stability():
     assert_array_equal(original_embedding,
                        fitter.embedding_,
                        "Transforming new data changed the original embeddings")
-    
+
     # Example from issue #217
     a = np.random.random((1000, 10))
     b = np.random.random((1000, 5))
@@ -980,6 +981,6 @@ def test_umap_transform_embedding_stability():
     u1 = umap.fit_transform(a[:, :5])
     u1_orig = u1.copy()
     assert_array_equal(u1_orig, umap.embedding_)
-    
+
     u2 = umap.transform(b)
     assert_array_equal(u1_orig, umap.embedding_)

--- a/umap/tests/test_umap.py
+++ b/umap/tests/test_umap.py
@@ -949,3 +949,37 @@ def test_umap_fit_params():
     x = np.random.uniform(0, 1, (256, 10))
     res = u.fit(x)
     assert isinstance(res, UMAP)
+
+def test_umap_transform_embedding_stability():
+    """Test that transforming data does not alter the learned embeddings
+    
+    Issue #217 describes how using transform to embed new data using a
+    trained UMAP transformer causes the fitting embedding matrix to change
+    in cases when the new data has the same number of rows as the original
+    training data.
+    """
+    
+    data = iris.data[iris_selection]
+    fitter = UMAP(n_neighbors=10, min_dist=0.01, random_state=42).fit(data)
+    original_embedding = fitter.embedding_.copy()
+
+    # The important point is that the new data has the same number of rows
+    # as the original fit data
+    new_data = np.random.random(data.shape)
+    embedding = fitter.transform(new_data)
+
+    assert_array_equal(original_embedding,
+                       fitter.embedding_,
+                       "Transforming new data changed the original embeddings")
+    
+    # Example from issue #217
+    a = np.random.random((1000, 10))
+    b = np.random.random((1000, 5))
+
+    umap = UMAP()
+    u1 = umap.fit_transform(a[:, :5])
+    u1_orig = u1.copy()
+    assert_array_equal(u1_orig, umap.embedding_)
+    
+    u2 = umap.transform(b)
+    assert_array_equal(u1_orig, umap.embedding_)

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1704,7 +1704,7 @@ class UMAP(BaseEstimator):
 
         embedding = optimize_layout(
             embedding,
-            self.embedding_.astype(np.float32, copy=True),  # Fixes #179 and #217
+            self.embedding_.astype(np.float32, copy=True),  # Fixes #179 & #217
             head,
             tail,
             n_epochs,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1704,7 +1704,7 @@ class UMAP(BaseEstimator):
 
         embedding = optimize_layout(
             embedding,
-            self.embedding_.astype(np.float32, copy=False),  # Fix #179
+            self.embedding_.astype(np.float32, copy=True),  # Fixes #179 and #217
             head,
             tail,
             n_epochs,


### PR DESCRIPTION
Update `umap_.transform` to pass a copy of `self.embedding_` to
`optimize_layout`

See [Issue 217](https://github.com/lmcinnes/umap/issues/217)

Fix #179 converted `self.embedding_` to np.float32 in the call to
optimize_layout, but the copy argument of np.ndarray.astype was set to
False. However, this had the effect of copying embedding_ when the dtype
was not np.float32 and passing the actual embedding_ data when it was
already np.float32. Given that optimize_layout should only be "touching"
the embedding_ but not modifying it, using copy=True in
np.ndarray.astype seemed the approriate fix.

This commit also adds a unit test to `test_umap.py` to handle these cases.