### PR TITLE
Fix NumbaPerformanceWarning by removing `parallel=True` usages that were having no effect

### DIFF
--- a/umap/nndescent.py
+++ b/umap/nndescent.py
@@ -43,7 +43,7 @@ def make_nn_descent(dist, dist_args):
     specialised to the given metric.
     """
 
-    @numba.njit(parallel=True)
+    @numba.njit()
     def nn_descent(
         data,
         n_neighbors,

--- a/umap/rp_tree.py
+++ b/umap/rp_tree.py
@@ -131,7 +131,7 @@ def angular_random_projection_split(data, indices, rng_state):
     return indices_left, indices_right, hyperplane_vector, None
 
 
-@numba.njit(fastmath=True, nogil=True, parallel=True)
+@numba.njit(fastmath=True, nogil=True)
 def euclidean_random_projection_split(data, indices, rng_state):
     """Given a set of ``indices`` for data points from ``data``, create
     a random hyperplane to split the data, returning two arrays indices

--- a/umap/utils.py
+++ b/umap/utils.py
@@ -405,7 +405,7 @@ def smallest_flagged(heap, row):
         return -1
 
 
-@numba.njit(parallel=True)
+@numba.njit()
 def build_candidates(current_graph, n_vertices, n_neighbors, max_candidates, rng_state):
     """Build a heap of candidate neighbors for nearest neighbor descent. For
     each vertex the candidate neighbors are any current neighbors, and any


### PR DESCRIPTION
The latest Numba (0.45.1) is giving warnings like

```
umap/tests/test_umap.py::test_nn_search
  /Users/tom/workspace/umap/venv/lib/python3.7/site-packages/numba/compiler.py:602: NumbaPerformanceWarning: 
  The keyword argument 'parallel=True' was specified but no transformation for parallel execution was possible.
  
  To find out why, try turning on parallel diagnostics, see http://numba.pydata.org/numba-doc/latest/user/parallel.html#diagnostics for help.
  
  File "umap/nndescent.py", line 135:
      @numba.njit(parallel=True)
      def init_from_tree(tree, data, query_points, heap, rng_state):
      ^
  
    self.func_ir.loc))
```

This change fixes the warnings.