### PR TITLE
Fix a typo

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1853,7 +1853,7 @@ class UMAP(BaseEstimator):
         if self._small_data:
             if self.metric in ("ll_dirichlet", "hellinger"):
                 dmat = dist.pairwise_special_metric(
-                    X, self._raw_data, dmetric=self.metric
+                    X, self._raw_data, metric=self.metric
                 )
             else:
                 dmat = pairwise_distances(


### PR DESCRIPTION
Fix a typo.
`distances.pairwise_special_metric()` accepts keyword parameter `metric`, not `dmetric`.
This conditional branch looks not executed during CI.