### PR TITLE
Set zip_safe=False to workaround numba cache issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ configuration = {
     'cmdclass' : {},
     'test_suite' : 'nose.collector',
     'tests_require' : ['nose'],
-    'data_files' : ()
+    'data_files' : (),
+    'zip_safe' : False
     }
 
 setup(**configuration)

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ def readme():
         return readme_file.read()
 
 configuration = {
-    'name' : 'umap-learn',
+    'name': 'umap-learn',
     'version': '0.4.0.rc1',
-    'description' : 'Uniform Manifold Approximation and Projection',
-    'long_description' : readme(),
-    'classifiers' : [
+    'description': 'Uniform Manifold Approximation and Projection',
+    'long_description': readme(),
+    'classifiers': [
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
@@ -26,23 +26,23 @@ configuration = {
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.8',
     ],
-    'keywords' : 'dimension reduction t-sne manifold',
-    'url' : 'http://github.com/lmcinnes/umap',
-    'maintainer' : 'Leland McInnes',
-    'maintainer_email' : 'leland.mcinnes@gmail.com',
-    'license' : 'BSD',
-    'packages' : ['umap'],
+    'keywords': 'dimension reduction t-sne manifold',
+    'url': 'http://github.com/lmcinnes/umap',
+    'maintainer': 'Leland McInnes',
+    'maintainer_email': 'leland.mcinnes@gmail.com',
+    'license': 'BSD',
+    'packages': ['umap'],
     'install_requires': ['numpy >= 1.13',
                          'scikit-learn >= 0.20',
                           'scipy >= 1.0',
                          'numba >= 0.42',
                          'tbb >= 2019.0'],
-    'ext_modules' : [],
-    'cmdclass' : {},
-    'test_suite' : 'nose.collector',
-    'tests_require' : ['nose'],
-    'data_files' : (),
-    'zip_safe' : False
+    'ext_modules': [],
+    'cmdclass': {},
+    'test_suite': 'nose.collector',
+    'tests_require': ['nose'],
+    'data_files': (),
+    'zip_safe': False
     }
 
 setup(**configuration)


### PR DESCRIPTION
We can get the `RuntimeError: cannot cache function 'rdist': no locator available` error when we try to use numba caching from a python egg package (e.g. if we installed umap through `python setup.py install`).

As a workaround, set the `zip_safe` flag to `False` to avoid installing it as egg file when we use the `setup.py install` command.