### PR TITLE
convert dists earlier in transform (fix for #324)

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1963,9 +1963,11 @@ class UMAP(BaseEstimator):
             indices = indices[:, : self._n_neighbors]
             dists = dists[:, : self._n_neighbors]
 
+        dists = dists.astype(np.float32, order='C')
+
         adjusted_local_connectivity = max(0.0, self.local_connectivity - 1.0)
         sigmas, rhos = smooth_knn_dist(
-            dists.astype(np.float32, order='C'),
+            dists,
             float(self._n_neighbors),
             local_connectivity=float(adjusted_local_connectivity),
         )


### PR DESCRIPTION
Proposed fix for #324. Upstream version passes a copy of `dists` converted to numpy type `float32` in the call to `smooth_knn_dists` but used the original value subsequently in `compute_membership_strengths`, which is why I think I was continuing to get the error in the referenced issue. This fix converts `dists` upfront to `float32`, which seems to fix it!