### PR TITLE
Correct handling of indices in tails of sparse_sum

### DIFF
--- a/umap/sparse.py
+++ b/umap/sparse.py
@@ -90,7 +90,7 @@ def sparse_sum(ind1, data1, ind2, data2):
     while i1 < ind1.shape[0]:
         val = data1[i1]
         if val != 0:
-            result_ind[nnz] = i1
+            result_ind[nnz] = ind1[i1]
             result_data[nnz] = val
             nnz += 1
         i1 += 1
@@ -98,7 +98,7 @@ def sparse_sum(ind1, data1, ind2, data2):
     while i2 < ind2.shape[0]:
         val = data2[i2]
         if val != 0:
-            result_ind[nnz] = i2
+            result_ind[nnz] = ind2[i2]
             result_data[nnz] = val
             nnz += 1
         i2 += 1


### PR DESCRIPTION
This pull request fixes what appears to be a bug in the `sparse_sum` function in the `sparse.py` class.  It appears that the piece of code dealing with the tails of the vectors is incorrect.  In particular, the lines like `result_ind[nnz] = i1` should be `result_ind[nnz] = ind1[i1]` to ensure the original vector indices are preserved.
