### PR TITLE
plot.py: Use `color_key` when datashading labels

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1340,10 +1340,11 @@ def interactive(
         hv.output(size=300)
         hv.opts('RGB [bgcolor="{}", xaxis=None, yaxis=None]'.format(background))
         if labels is not None:
-            point_plot = hv.Points(data, kdims=["x", "y"], vdims=["color"])
+            point_plot = hv.Points(data, kdims=["x", "y"])
             plot = hd.datashade(
                 point_plot,
                 aggregator=ds.count_cat("color"),
+                color_key=color_key,
                 cmap=plt.get_cmap(cmap),
                 width=width,
                 height=height,


### PR DESCRIPTION
Pass `color_key` to datashader when labels are provided. When `ds.count_cat` is used, the colors of the categories can be specified with `color_key`.

This allows the user to specify colors when plotting large data with labels; currently, colors cannot be specified, and if there are more than 22 labels this codepath throws an error.

Also, remove the `vdim` on the `hv.Points` plot since it is not used.