### PR TITLE
custom distance metrics for transform & inverse transform, plus some other bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,23 @@
+# virtual environment
 venv
+
+# non-stylistic pycharm configs
 .idea/misc.xml
 .idea/modules.xml
 .idea/umap.iml
 .idea/vcs.xml
 .idea/workspace.xml
 .idea/dictionaries
+
+# Mac Finder layout
 .DS_Store
+
+# IPython/Jupyter notebook checkpoints
+*.ipynb_checkpoints
+
+# Python 2.x & 3.x bytecode cache
+*.pyc
+*__pycache__
+
+# metadata from pip-installing repo
+umap_learn.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 .idea/vcs.xml
 .idea/workspace.xml
 .idea/dictionaries
+.DS_Store

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -204,7 +204,7 @@ intersphinx_mapping = {
 sphinx_gallery_conf = {
     # path to your examples scripts
     "examples_dirs": "../examples",
-    'ignore_pattern': r'(.*torus.*|inverse_transform.*)\.py',
+    "ignore_pattern": r"(.*torus.*|inverse_transform.*)\.py",
     # path where to save gallery generated examples
     "gallery_dirs": "auto_examples",
     "plot_gallery": False,  # Turn off running the examples for now

--- a/doc/plotting_example_interactive.py
+++ b/doc/plotting_example_interactive.py
@@ -4,29 +4,29 @@ import numpy as np
 import umap
 import umap.plot
 
-fmnist = sklearn.datasets.fetch_openml('Fashion-MNIST')
+fmnist = sklearn.datasets.fetch_openml("Fashion-MNIST")
 
 mapper = umap.UMAP().fit(fmnist.data[:30000])
 
-hover_data = pd.DataFrame({'index': np.arange(30000),
-                           'label': fmnist.target[:30000]})
-hover_data['item'] = hover_data.label.map(
+hover_data = pd.DataFrame({"index": np.arange(30000), "label": fmnist.target[:30000]})
+hover_data["item"] = hover_data.label.map(
     {
-        '0': 'T-shirt/top',
-        '1': 'Trouser',
-        '2': 'Pullover',
-        '3': 'Dress',
-        '4': 'Coat',
-        '5': 'Sandal',
-        '6': 'Shirt',
-        '7': 'Sneaker',
-        '8': 'Bag',
-        '9': 'Ankle Boot',
+        "0": "T-shirt/top",
+        "1": "Trouser",
+        "2": "Pullover",
+        "3": "Dress",
+        "4": "Coat",
+        "5": "Sandal",
+        "6": "Shirt",
+        "7": "Sneaker",
+        "8": "Bag",
+        "9": "Ankle Boot",
     }
 )
 
-umap.plot.output_file('plotting_interactive_example.html')
+umap.plot.output_file("plotting_interactive_example.html")
 
-p = umap.plot.interactive(mapper, labels=fmnist.target[:30000], hover_data=hover_data,
-                          point_size=2)
+p = umap.plot.interactive(
+    mapper, labels=fmnist.target[:30000], hover_data=hover_data, point_size=2
+)
 umap.plot.show(p)

--- a/examples/inverse_transform_example.py
+++ b/examples/inverse_transform_example.py
@@ -12,38 +12,44 @@ mnist = fetch_mldata("MNIST original")
 trans = umap.UMAP(
     n_neighbors=10,
     random_state=42,
-    metric='euclidean',
-    output_metric='euclidean',
-    init='spectral',
+    metric="euclidean",
+    output_metric="euclidean",
+    init="spectral",
     verbose=True,
 ).fit(mnist.data)
 
-corners = np.array([
-    [-5.1, 2.9],  # 7
-    [-1.9, 6.4],  # 4
-    [-5.4, -6.3],  # 1
-    [8.3, 4.0],  # 0
-])
+corners = np.array(
+    [[-5.1, 2.9], [-1.9, 6.4], [-5.4, -6.3], [8.3, 4.0],]  # 7  # 4  # 1  # 0
+)
 
-test_pts = np.array([
-    (corners[0]*(1-x) + corners[1]*x)*(1-y) +
-    (corners[2]*(1-x) + corners[3]*x)*y
-    for y in np.linspace(0, 1, 10)
-    for x in np.linspace(0, 1, 10)
-])
+test_pts = np.array(
+    [
+        (corners[0] * (1 - x) + corners[1] * x) * (1 - y)
+        + (corners[2] * (1 - x) + corners[3] * x) * y
+        for y in np.linspace(0, 1, 10)
+        for x in np.linspace(0, 1, 10)
+    ]
+)
 
 inv_transformed_points = trans.inverse_transform(test_pts)
 
-plt.scatter(trans.embedding_[:, 0], trans.embedding_[:, 1],
-            c=mnist.target, cmap='Spectral', s=0.25)
-plt.colorbar(boundaries=np.arange(11)-0.5).set_ticks(np.arange(10))
-plt.scatter(test_pts[:, 0], test_pts[:, 1], marker='x', c='k')
+plt.scatter(
+    trans.embedding_[:, 0],
+    trans.embedding_[:, 1],
+    c=mnist.target,
+    cmap="Spectral",
+    s=0.25,
+)
+plt.colorbar(boundaries=np.arange(11) - 0.5).set_ticks(np.arange(10))
+plt.scatter(test_pts[:, 0], test_pts[:, 1], marker="x", c="k")
 
 fig, ax = plt.subplots(10, 10)
 for i in range(10):
     for j in range(10):
-        ax[i,j].imshow(inv_transformed_points[i*10+j].reshape(28, 28), origin='upper')
-        ax[i,j].get_xaxis().set_visible(False)
-        ax[i,j].get_yaxis().set_visible(False)
+        ax[i, j].imshow(
+            inv_transformed_points[i * 10 + j].reshape(28, 28), origin="upper"
+        )
+        ax[i, j].get_xaxis().set_visible(False)
+        ax[i, j].get_yaxis().set_visible(False)
 
 plt.show()

--- a/examples/mnist_torus_sphere_example.py
+++ b/examples/mnist_torus_sphere_example.py
@@ -11,36 +11,35 @@ import umap
 
 digits = load_digits()
 X_train, X_test, y_train, y_test = train_test_split(
-    digits.data,
-    digits.target,
-    stratify=digits.target,
-    random_state=42
+    digits.data, digits.target, stratify=digits.target, random_state=42
 )
 
-target_spaces = ['plane', 'torus', 'sphere']
+target_spaces = ["plane", "torus", "sphere"]
 
-if 'plane' in target_spaces:
+if "plane" in target_spaces:
     # embed onto a plane
 
     trans = umap.UMAP(
         n_neighbors=10,
         random_state=42,
-        metric='euclidean',
-        output_metric='euclidean',
-        init='spectral',
+        metric="euclidean",
+        output_metric="euclidean",
+        init="spectral",
         verbose=True,
     ).fit(X_train)
 
-    plt.scatter(trans.embedding_[:, 0], trans.embedding_[:, 1], c=y_train, cmap='Spectral')
+    plt.scatter(
+        trans.embedding_[:, 0], trans.embedding_[:, 1], c=y_train, cmap="Spectral"
+    )
     plt.show()
 
-if 'torus' in target_spaces:
+if "torus" in target_spaces:
     # embed onto a torus
     # note: this is a topological torus, not a geometric torus. Think
     # Pacman, not donut.
 
     @numba.njit(fastmath=True)
-    def torus_euclidean_grad(x, y, torus_dimensions=(2*np.pi,2*np.pi)):
+    def torus_euclidean_grad(x, y, torus_dimensions=(2 * np.pi, 2 * np.pi)):
         """Standard euclidean distance.
 
         ..math::
@@ -50,21 +49,21 @@ if 'torus' in target_spaces:
         g = np.zeros_like(x)
         for i in range(x.shape[0]):
             a = abs(x[i] - y[i])
-            if 2*a < torus_dimensions[i]:
+            if 2 * a < torus_dimensions[i]:
                 distance_sqr += a ** 2
-                g[i] = (x[i] - y[i])
+                g[i] = x[i] - y[i]
             else:
-                distance_sqr += (torus_dimensions[i]-a) ** 2
+                distance_sqr += (torus_dimensions[i] - a) ** 2
                 g[i] = (x[i] - y[i]) * (a - torus_dimensions[i]) / a
         distance = np.sqrt(distance_sqr)
-        return distance, g/(1e-6 + distance)
+        return distance, g / (1e-6 + distance)
 
     trans = umap.UMAP(
         n_neighbors=10,
         random_state=42,
-        metric='euclidean',
+        metric="euclidean",
         output_metric=torus_euclidean_grad,
-        init='spectral',
+        init="spectral",
         min_dist=0.15,  # requires adjustment since the torus has limited space
         verbose=True,
     ).fit(X_train)
@@ -75,7 +74,7 @@ if 'torus' in target_spaces:
     # Plot a torus
     R = 2
     r = 1
-    values = (R - np.sqrt(x**2 + y**2))**2 + z**2 - r**2
+    values = (R - np.sqrt(x ** 2 + y ** 2)) ** 2 + z ** 2 - r ** 2
     mlab.contour3d(x, y, z, values, color=(1.0, 1.0, 1.0), contours=[0])
 
     # torus angles -> 3D
@@ -83,18 +82,20 @@ if 'torus' in target_spaces:
     y = (R + r * np.cos(trans.embedding_[:, 0])) * np.sin(trans.embedding_[:, 1])
     z = r * np.sin(trans.embedding_[:, 0])
 
-    pts = mlab.points3d(x, y, z, y_train, colormap="spectral", scale_mode='none', scale_factor=.1)
+    pts = mlab.points3d(
+        x, y, z, y_train, colormap="spectral", scale_mode="none", scale_factor=0.1
+    )
 
     mlab.show()
 
-if 'sphere' in target_spaces:
+if "sphere" in target_spaces:
     # embed onto a sphere
     trans = umap.UMAP(
         n_neighbors=10,
         random_state=42,
-        metric='euclidean',
-        output_metric='haversine',
-        init='spectral',
+        metric="euclidean",
+        output_metric="haversine",
+        init="spectral",
         min_dist=0.15,  # requires adjustment since the sphere has limited space
         verbose=True,
     ).fit(X_train)
@@ -112,6 +113,8 @@ if 'sphere' in target_spaces:
     y = r * np.sin(trans.embedding_[:, 0]) * np.sin(trans.embedding_[:, 1])
     z = r * np.cos(trans.embedding_[:, 0])
 
-    pts = mlab.points3d(x, y, z, y_train, colormap="spectral", scale_mode='none', scale_factor=.2)
+    pts = mlab.points3d(
+        x, y, z, y_train, colormap="spectral", scale_mode="none", scale_factor=0.2
+    )
 
     mlab.show()

--- a/examples/mnist_transform_new_data.py
+++ b/examples/mnist_transform_new_data.py
@@ -24,12 +24,9 @@ import umap
 
 sns.set(context="paper", style="white")
 
-mnist = fetch_openml('mnist_784', version=1)
+mnist = fetch_openml("mnist_784", version=1)
 X_train, X_test, y_train, y_test = train_test_split(
-    mnist.data,
-    mnist.target,
-    stratify=mnist.target,
-    random_state=42
+    mnist.data, mnist.target, stratify=mnist.target, random_state=42
 )
 
 reducer = umap.UMAP(random_state=42)

--- a/setup.py
+++ b/setup.py
@@ -8,62 +8,57 @@ def readme():
     except TypeError:
         # Python 2.7 doesn't support encoding argument in builtin open
         import io
+
         with io.open("README.rst", encoding="UTF-8") as readme_file:
             return readme_file.read()
 
 
 configuration = {
-    'name': 'umap-learn',
-    'version': '0.4.0.rc1',
-    'description': 'Uniform Manifold Approximation and Projection',
-    'long_description': readme(),
-    'long_description_content_type': 'text/x-rst',
-    'classifiers': [
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved',
-        'Programming Language :: C',
-        'Programming Language :: Python',
-        'Topic :: Software Development',
-        'Topic :: Scientific/Engineering',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX',
-        'Operating System :: Unix',
-        'Operating System :: MacOS',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
+    "name": "umap-learn",
+    "version": "0.4.0.rc1",
+    "description": "Uniform Manifold Approximation and Projection",
+    "long_description": readme(),
+    "long_description_content_type": "text/x-rst",
+    "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved",
+        "Programming Language :: C",
+        "Programming Language :: Python",
+        "Topic :: Software Development",
+        "Topic :: Scientific/Engineering",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Operating System :: MacOS",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
     ],
-    'keywords': 'dimension reduction t-sne manifold',
-    'url': 'http://github.com/lmcinnes/umap',
-    'maintainer': 'Leland McInnes',
-    'maintainer_email': 'leland.mcinnes@gmail.com',
-    'license': 'BSD',
-    'packages': ['umap'],
-    'install_requires': ['numpy >= 1.13',
-                         'scikit-learn >= 0.20',
-                         'scipy >= 1.0',
-                         'numba >= 0.42, != 0.47',
-                         'tbb >= 2019.0'],
-    'extras_require': {
-        'plot': [
-            'matplotlib',
-            'datashader',
-            'bokeh',
-            'holoviews',
-            'seaborn'
-        ],
-        'performance': [
-            'pynndescent >= 0.4'
-        ]
+    "keywords": "dimension reduction t-sne manifold",
+    "url": "http://github.com/lmcinnes/umap",
+    "maintainer": "Leland McInnes",
+    "maintainer_email": "leland.mcinnes@gmail.com",
+    "license": "BSD",
+    "packages": ["umap"],
+    "install_requires": [
+        "numpy >= 1.13",
+        "scikit-learn >= 0.20",
+        "scipy >= 1.0",
+        "numba >= 0.42, != 0.47",
+        "tbb >= 2019.0",
+    ],
+    "extras_require": {
+        "plot": ["matplotlib", "datashader", "bokeh", "holoviews", "seaborn"],
+        "performance": ["pynndescent >= 0.4"],
     },
-    'ext_modules': [],
-    'cmdclass': {},
-    'test_suite': 'nose.collector',
-    'tests_require': ['nose'],
-    'data_files': (),
-    'zip_safe': False
-    }
+    "ext_modules": [],
+    "cmdclass": {},
+    "test_suite": "nose.collector",
+    "tests_require": ["nose"],
+    "data_files": (),
+    "zip_safe": False,
+}
 
 setup(**configuration)

--- a/umap/distances.py
+++ b/umap/distances.py
@@ -1175,10 +1175,10 @@ def pairwise_special_metric(X, Y=None, metric="hellinger", kwds=None):
         kwd_vals = tuple(kwds.values())
 
         @numba.njit(fastmath=True)
-        def _pairwise_numba(_X, _Y=None):
+        def _partial_metric(_X, _Y=None):
             return metric(_X, _Y, *kwd_vals)
-        
-        return pairwise_distances(X, Y, metric=_pairwise_numba)
+
+        return pairwise_distances(X, Y, metric=_partial_metric)
     else:
         special_metric_func = named_distances[metric]
     return parallel_special_metric(X, Y, metric=special_metric_func)

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -507,7 +507,7 @@ def optimize_layout_inverse(
                 )
 
                 w_l = weight[i]
-                grad_coeff = -(1 / (w_l * sigmas[j] + 1e-6))
+                grad_coeff = -(1 / (w_l * sigmas[k] + 1e-6))
 
                 for d in range(dim):
                     grad_d = clip(grad_coeff * grad_dist_output[d])

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -448,7 +448,9 @@ def show(plot_to_show):
     elif isinstance(plot_to_show, bpl.Figure):
         show_interactive(plot_to_show)
     else:
-        raise ValueError("The type of ``plot_to_show`` was not valid, or not understood.")
+        raise ValueError(
+            "The type of ``plot_to_show`` was not valid, or not understood."
+        )
 
 
 def points(

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1743,7 +1743,7 @@ class UMAP(BaseEstimator):
                 X[index],
                 self.n_neighbors,
                 random_state,
-                self.nn_metric,
+                nn_metric,
                 self.metric_kwds,
                 self._knn_indices,
                 self._knn_dists,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -59,6 +59,7 @@ from umap.layouts import (
 try:
     # Use pynndescent, if installed (python 3 only)
     from pynndescent import NNDescent
+    from pynndescent.distances import named_distances as pynn_named_distances
 
     _HAVE_PYNNDESCENT = True
 except ImportError:
@@ -1725,8 +1726,8 @@ class UMAP(BaseEstimator):
         else:
             # Standard case
             self._small_data = False
-            # pynndescent doesn't accept callable functions for sparse data
-            if _HAVE_PYNNDESCENT and self._sparse_data and isinstance(self.metric, str):
+            # pass string identifier if pynndescent also defines distance metric
+            if (_HAVE_PYNNDESCENT) and (self.metric in pynn_named_distances):
                 nn_metric = self.metric
             else:
                 nn_metric = self._input_distance_func

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1477,7 +1477,7 @@ class UMAP(BaseEstimator):
         if callable(self.metric):
             in_returns_grad = self._check_custom_metric(self.metric, self.metric_kwds, self._raw_data)
             if in_returns_grad:
-                self._input_distance_func = lambda x, y, kwds: self.metric(x, y, **kwds)[0]
+                self._input_distance_func = lambda x, y, **kwargs: self.metric(x, y, **kwargs)[0]
                 self._inverse_distance_func = self.metric
             else:
                 self._input_distance_func = self.metric
@@ -2168,7 +2168,7 @@ class UMAP(BaseEstimator):
             for v in neighbors
         ]
         dist_func = dist.named_distances[self.output_metric]
-        dist_args = tuple(self.output_metrickwds.values())
+        dist_args = tuple(self.output_metric_kwds.values())
         distances = [
             np.array(
                 [

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -305,9 +305,7 @@ def nearest_neighbors(
             # elif metric in dist.named_distances:
             #     _distance_func = dist.named_distances[metric]
             else:
-                raise ValueError(
-                    "Metric is neither callable, nor a recognised string"
-                )
+                raise ValueError("Metric is neither callable, nor a recognised string")
 
             rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
 
@@ -1477,10 +1475,12 @@ class UMAP(BaseEstimator):
             )
             if in_returns_grad:
                 _m = self.metric
+
                 @numba.njit(fastmath=True)
                 def _dist_only(x, y, *kwds):
                     return _m(x, y, *kwds)[0]
-                self._input_distance_func =  _dist_only
+
+                self._input_distance_func = _dist_only
                 self._inverse_distance_func = self.metric
             else:
                 self._input_distance_func = self.metric
@@ -1504,9 +1504,13 @@ class UMAP(BaseEstimator):
         elif self.metric in dist.named_distances:
             if self._sparse_data:
                 if self.metric in sparse.sparse_named_distances:
-                    self._input_distance_func = sparse.sparse_named_distances[self.metric]
+                    self._input_distance_func = sparse.sparse_named_distances[
+                        self.metric
+                    ]
                 else:
-                    raise ValueError("Metric {} is not supported for sparse data".format(self.metric))
+                    raise ValueError(
+                        "Metric {} is not supported for sparse data".format(self.metric)
+                    )
             else:
                 self._input_distance_func = dist.named_distances[self.metric]
             try:
@@ -1549,7 +1553,14 @@ class UMAP(BaseEstimator):
                 "output_metric is neither callable nor a recognised string"
             )
         # set angularity for NN search based on metric
-        if self.metric in ("cosine", "correlation", "dice", "jaccard", "ll_dirichlet", "hellinger"):
+        if self.metric in (
+            "cosine",
+            "correlation",
+            "dice",
+            "jaccard",
+            "ll_dirichlet",
+            "hellinger",
+        ):
             self.angular_rp_forest = True
 
     def _check_custom_metric(self, metric, kwds, data=None):
@@ -1775,9 +1786,7 @@ class UMAP(BaseEstimator):
 
                         @numba.njit()
                         def _partial_dist_func(ind1, data1, ind2, data2):
-                            return _distance_func(
-                                ind1, data1, ind2, data2, *_dist_args
-                            )
+                            return _distance_func(ind1, data1, ind2, data2, *_dist_args)
 
                         self._input_distance_func = _partial_dist_func
                     else:
@@ -1996,10 +2005,7 @@ class UMAP(BaseEstimator):
                 # sklearn pairwise_distances fails for callable metric on sparse data
                 _m = self.metric if self._sparse_data else self._input_distance_func
                 dmat = pairwise_distances(
-                    X,
-                    self._raw_data,
-                    metric=_m,
-                    **self.metric_kwds
+                    X, self._raw_data, metric=_m, **self.metric_kwds
                 )
             except (TypeError, ValueError):
                 dmat = dist.pairwise_special_metric(

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2173,16 +2173,12 @@ class UMAP(BaseEstimator):
             breadth_first_search(adjmat, v[0], min_vertices=min_vertices)
             for v in neighbors
         ]
-        dist_func = dist.named_distances[self.output_metric]
         dist_args = tuple(self.output_metric_kwds.values())
         distances = [
             np.array(
-                [
-                    dist_func(X[i], self.embedding_[nb], *dist_args)
-                    for nb in neighborhood[i]
-                ]
-            )
-            for i in range(X.shape[0])
+                [self._output_distance_func(X[i], self.embedding_[nb], *dist_args)
+                 for nb in neighborhood[i]]
+            ) for i in range(X.shape[0])
         ]
         idx = np.array([np.argsort(e)[:min_vertices] for e in distances])
 

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1720,12 +1720,17 @@ class UMAP(BaseEstimator):
                 self.verbose,
             )
         else:
-            self._small_data = False
             # Standard case
+            self._small_data = False
+            # pynndescent doesn't accept callable functions for sparse data
+            if _HAVE_PYNNDESCENT and self._sparse_data and isinstance(self.metric, str):
+                nn_metric = self.metric
+            else:
+                nn_metric = self._input_distance_func
             (self._knn_indices, self._knn_dists, self._rp_forest) = nearest_neighbors(
                 X[index],
                 self._n_neighbors,
-                self._input_distance_func,
+                nn_metric,
                 self.metric_kwds,
                 self.angular_rp_forest,
                 random_state,
@@ -1738,7 +1743,7 @@ class UMAP(BaseEstimator):
                 X[index],
                 self.n_neighbors,
                 random_state,
-                self._input_distance_func,
+                self.nn_metric,
                 self.metric_kwds,
                 self._knn_indices,
                 self._knn_dists,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1477,10 +1477,10 @@ class UMAP(BaseEstimator):
         if callable(self.metric):
             in_returns_grad = self._check_custom_metric(self.metric, self.metric_kwds, self._raw_data)
             if in_returns_grad:
-                m = self.metric
+                _m = self.metric
                 @numba.njit(fastmath=True)
                 def _dist_only(x, y, *kwds):
-                    return m(x, y, *kwds)[0]
+                    return _m(x, y, *kwds)[0]
                 self._input_distance_func = _dist_only  # lambda x, y, **kwargs: self.metric(x, y, **kwargs)[0]
                 self._inverse_distance_func = self.metric
             else:
@@ -2142,11 +2142,8 @@ class UMAP(BaseEstimator):
 
         if self._sparse_data:
             raise ValueError("Inverse transform not available for sparse input.")
-        elif self.metric == "precomputed":
-            raise ValueError(
-                "Inverse transform  of new data not available for "
-                "precomputed metric."
-            )
+        elif self._inverse_distance_func is None:
+            raise ValueError("Inverse transform not available for given metric.")
 
         X = check_array(X, dtype=np.float32, order="C")
         random_state = check_random_state(self.transform_seed)

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1652,8 +1652,10 @@ class UMAP(BaseEstimator):
         if X[index].shape[0] < 4096 and not self.force_approximation_algorithm:
             self._small_data = True
             try:
+                # sklearn pairwise_distances fails for callable metric on sparse data
+                _m = self.metric if self._sparse_data else self._input_distance_func
                 dmat = pairwise_distances(
-                    X[index], metric=self._input_distance_func, **self.metric_kwds
+                    X[index], metric=_m, **self.metric_kwds
                 )
             except (ValueError, TypeError) as e:
                 # metric is numba.jit'd or not supported by sklearn,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -60,6 +60,7 @@ try:
     # Use pynndescent, if installed (python 3 only)
     from pynndescent import NNDescent
     from pynndescent.distances import named_distances as pynn_named_distances
+    from pynndescent.sparse import sparse_named_distances as pynn_sparse_named_distances
 
     _HAVE_PYNNDESCENT = True
 except ImportError:
@@ -1727,8 +1728,13 @@ class UMAP(BaseEstimator):
             # Standard case
             self._small_data = False
             # pass string identifier if pynndescent also defines distance metric
-            if (_HAVE_PYNNDESCENT) and (self.metric in pynn_named_distances):
-                nn_metric = self.metric
+            if _HAVE_PYNNDESCENT:
+                if self._sparse_data and self.metric in pynn_sparse_named_distances:
+                    nn_metric = self.metric
+                elif not self._sparse_data and self.metric in pynn_named_distances:
+                    nn_metric = self.metric
+                else:
+                    nn_metric = self._input_distance_func
             else:
                 nn_metric = self._input_distance_func
             (self._knn_indices, self._knn_dists, self._rp_forest) = nearest_neighbors(

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2248,27 +2248,6 @@ class UMAP(BaseEstimator):
         tail = graph.col
         weight = graph.data
 
-        if callable(self.metric):
-            _input_distance_func = self.metric
-        elif (
-            self.metric in dist.named_distances
-            and self.metric in dist.named_distances_with_gradients
-        ):
-            _input_distance_func = dist.named_distances_with_gradients[self.metric]
-        elif self.metric == "precomputed":
-            raise ValueError("metric cannnot be 'precomputed'")
-        else:
-            if self.output_metric in dist.named_distances:
-                raise ValueError(
-                    "gradient function is not yet implemented for "
-                    + repr(self.output_metric)
-                    + "."
-                )
-            else:
-                raise ValueError(
-                    "output_metric is neither callable, " + "nor a recognised string"
-                )
-
         inv_transformed_points = optimize_layout_inverse(
             inv_transformed_points,
             self._raw_data,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1100,7 +1100,6 @@ def simplicial_set_embedding(
             verbose=verbose,
         )
     else:
-        print("using optimize_layout_generic")
         embedding = optimize_layout_generic(
             embedding,
             embedding,
@@ -1657,14 +1656,13 @@ class UMAP(BaseEstimator):
                     X[index], metric=self._input_distance_func, **self.metric_kwds
                 )
             except (ValueError, TypeError) as e:
-                # metric is not supported by sklearn,
+                # metric is numba.jit'd or not supported by sklearn,
                 # fallback to pairwise special
                 if self._sparse_data:
                     dmat = dist.pairwise_special_metric(
-                        X[index].toarray(), metric=self._input_distance_func
-                    )
+                        X[index].toarray(), metric=self._input_distance_func, kwds=self.metric_kwds)
                 else:
-                    dmat = dist.pairwise_special_metric(X[index], metric=self._input_distance_func)
+                    dmat = dist.pairwise_special_metric(X[index], metric=self._input_distance_func, kwds=self.metric_kwds)
             self.graph_, self._sigmas, self._rhos = fuzzy_simplicial_set(
                 dmat,
                 self._n_neighbors,
@@ -1890,7 +1888,7 @@ class UMAP(BaseEstimator):
             n_epochs,
             init,
             random_state,
-            self.metric,
+            self._input_distance_func,
             self.metric_kwds,
             self._output_distance_func,
             self.output_metric_kwds,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1745,9 +1745,6 @@ class UMAP(BaseEstimator):
                 )
                 _rows = []
                 _data = []
-                # for i in range(self._knn_indices.shape[0]):
-                #     _rows.append(self._knn_indices[self._knn_indices >= 0])
-                #     _data.append(np.ones(_rows[-1].shape[0], dtype=np.int8))
                 for i in self._knn_indices:
                     _non_neg = i[i >= 0]
                     _rows.append(_non_neg)

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1715,9 +1715,14 @@ class UMAP(BaseEstimator):
                 )
                 _rows = []
                 _data = []
-                for i in range(self._knn_indices.shape[0]):
-                    _rows.append(self._knn_indices[self._knn_indices >= 0])
-                    _data.append(np.ones(_rows[-1].shape[0], dtype=np.int8))
+                # for i in range(self._knn_indices.shape[0]):
+                #     _rows.append(self._knn_indices[self._knn_indices >= 0])
+                #     _data.append(np.ones(_rows[-1].shape[0], dtype=np.int8))
+                for i in self._knn_indices:
+                    _non_neg = i[i >= 0]
+                    _rows.append(_non_neg)
+                    _data.append((_non_neg > 0).astype(np.int8))
+
                 self._search_graph.rows = _rows
                 self._search_graph.data = _data
                 self._search_graph = self._search_graph.maximum(

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1388,16 +1388,21 @@ class UMAP(BaseEstimator):
         verbose=False,
         unique=False,
     ):
-
         self.n_neighbors = n_neighbors
         self.metric = metric
-        self.metric_kwds = metric_kwds
         self.output_metric = output_metric
-        if output_metric_kwds is not None:
-            self._output_metric_kwds = output_metric_kwds
+        if metric_kwds is None:
+            self.metric_kwds = {}
         else:
-            self._output_metric_kwds = {}
-
+            self.metric_kwds = metric_kwds
+        if target_metric_kwds is None:
+            self.target_metric_kwds = {}
+        else:
+            self.target_metric_kwds = target_metric_kwds
+        if output_metric_kwds is None:
+            self.output_metric_kwds = {}
+        else:
+            self._output_metric_kwds = output_metric_kwds
         self.n_epochs = n_epochs
         self.init = init
         self.n_components = n_components
@@ -1512,9 +1517,8 @@ class UMAP(BaseEstimator):
         else:
             raise ValueError("output_metric is neither callable nor a recognised string")
 
-
     def _check_custom_metric(self, metric, kwds, data=None):
-        # quick check to determine whether user-defined
+        # quickly check to determine whether user-defined
         # self.metric/self.output_metric returns both distance and gradient
         if data is not None:
             # if checking the high-dimensional distance metric, test directly on
@@ -1558,16 +1562,6 @@ class UMAP(BaseEstimator):
         else:
             self._a = self.a
             self._b = self.b
-
-        if self.metric_kwds is not None:
-            self._metric_kwds = self.metric_kwds
-        else:
-            self._metric_kwds = {}
-
-        if self.target_metric_kwds is not None:
-            self._target_metric_kwds = self.target_metric_kwds
-        else:
-            self._target_metric_kwds = {}
 
         if isinstance(self.init, np.ndarray):
             init = check_array(self.init, dtype=np.float32, accept_sparse=False)

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -302,24 +302,25 @@ def nearest_neighbors(
             # Otherwise fall back to nn descent in umap
             if callable(metric):
                 _distance_func = metric
-            # elif metric in dist.named_distances:
-            #     _distance_func = dist.named_distances[metric]
+            elif metric in dist.named_distances:
+                _distance_func = dist.named_distances[metric]
             else:
                 raise ValueError("Metric is neither callable, nor a recognised string")
 
             rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
 
             if scipy.sparse.isspmatrix_csr(X):
-                # if metric in sparse.sparse_named_distances:
-                #     _distance_func = sparse.sparse_named_distances[metric]
-                #     if metric in sparse.sparse_need_n_features:
-                #         metric_kwds["n_features"] = X.shape[1]
-                # elif callable(metric):
-                #     _distance_func = metric
-                # else:
-                #     raise ValueError(
-                #         "Metric {} not supported for sparse " + "data".format(metric)
-                #     )
+                if callable(metric):
+                    _distance_func = metric
+                else:
+                    try:
+                        _distance_func = sparse.sparse_named_distances[metric]
+                        if metric in sparse.sparse_need_n_features:
+                            metric_kwds["n_features"] = X.shape[1]
+                    except KeyError as e:
+                        raise ValueError(
+                            "Metric {} not supported for sparse data".format(metric)
+                        ) from e
 
                 # Create a partial function for distances with arguments
                 if len(metric_kwds) > 0:

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1996,10 +1996,12 @@ class UMAP(BaseEstimator):
 
         if self._small_data:
             try:
+                # sklearn pairwise_distances fails for callable metric on sparse data
+                _m = self.metric if self._sparse_data else self._input_distance_func
                 dmat = pairwise_distances(
                     X,
                     self._raw_data,
-                    metric=self._input_distance_func,
+                    metric=_m,
                     **self.metric_kwds
                 )
             except (TypeError, ValueError):

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -309,16 +309,6 @@ def nearest_neighbors(
                     "Metric is neither callable, " + "nor a recognised string"
                 )
 
-            if metric in (
-                "cosine",
-                "correlation",
-                "dice",
-                "jaccard",
-                "ll_dirichlet",
-                "hellinger",
-            ):
-                angular = True
-
             rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
 
             if scipy.sparse.isspmatrix_csr(X):
@@ -1480,6 +1470,7 @@ class UMAP(BaseEstimator):
             self._sparse_data = True
         else:
             self._sparse_data = False
+        # set input distance metric & inverse_transform distance metric
         if callable(self.metric):
             in_returns_grad = self._check_custom_metric(
                 self.metric, self.metric_kwds, self._raw_data
@@ -1530,6 +1521,7 @@ class UMAP(BaseEstimator):
                 self._inverse_distance_func = None
         else:
             raise ValueError("metric is neither callable nor a recognised string")
+        # set ooutput distance metric
         if callable(self.output_metric):
             out_returns_grad = self._check_custom_metric(
                 self.output_metric, self.output_metric_kwds
@@ -1556,6 +1548,9 @@ class UMAP(BaseEstimator):
             raise ValueError(
                 "output_metric is neither callable nor a recognised string"
             )
+        # set angularity for NN search based on metric
+        if self.metric in ("cosine", "correlation", "dice", "jaccard", "ll_dirichlet", "hellinger"):
+            self.angular_rp_forest = True
 
     def _check_custom_metric(self, metric, kwds, data=None):
         # quickly check to determine whether user-defined

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1766,19 +1766,6 @@ class UMAP(BaseEstimator):
                     self._search_graph.transpose()
                 ).tocsr()
 
-                # if callable(self.metric):
-                #     _distance_func = self._input_distance_func
-                # elif self.metric in dist.named_distances:
-                #     # Choose the right metric based on sparsity
-                #     if self._sparse_data:
-                #         _distance_func = sparse.sparse_named_distances[self.metric]
-                #     else:
-                #         _distance_func = dist.named_distances[self.metric]
-                # else:
-                #     raise ValueError(
-                #         "Metric is neither callable, nor a recognised string"
-                #     )
-                # _distance_func = self._input_distance_func
                 if (self.metric != "precomputed") and (len(self.metric_kwds) > 0):
                     # Create a partial function for distances with arguments
                     _distance_func = self._input_distance_func
@@ -1797,15 +1784,6 @@ class UMAP(BaseEstimator):
                             return _distance_func(x, y, *_dist_args)
 
                         self._input_distance_func = _partial_dist_func
-                    # else:
-                    #     self._input_distance_func = _distance_func
-
-                # self._random_init, self._tree_init = make_initialisations(
-                #     self._distance_func, self._dist_args
-                # )
-                # self._search = make_initialized_nnd_search(
-                #     self._distance_func, self._dist_args
-                # )
 
         # Currently not checking if any duplicate points have differing labels
         # Might be worth throwing a warning...

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1751,7 +1751,7 @@ class UMAP(BaseEstimator):
                 for i in self._knn_indices:
                     _non_neg = i[i >= 0]
                     _rows.append(_non_neg)
-                    _data.append((_non_neg > 0).astype(np.int8))
+                    _data.append(np.ones(_non_neg.shape[0], dtype=np.int8))
 
                 self._search_graph.rows = _rows
                 self._search_graph.data = _data

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1485,6 +1485,14 @@ class UMAP(BaseEstimator):
                 warn("custom distance metric does not return gradient; inverse_transform will be unavailable. "
                      "To enable using inverse_transform method method, define a distance function that returns "
                      "a tuple of (distance [float], gradient [np.array])")
+        elif self.metric == "precomputed":
+            if self.unique is False:
+                raise ValueError("unique is poorly defined on a precomputed metric")
+            warn("using precomputed metric; transform will be unavailable for new data and inverse_transform "
+                 "will be unavailable for all data")
+            self._inverse_distance_func = None
+        elif self.metric == "hellinger" and self._raw_data.min() < 0:
+            raise ValueError("Metric 'hellinger' does not support negative values")
         elif self.metric in dist.named_distances:
             self._input_distance_func = dist.named_distances[self.metric]
             try:
@@ -1493,12 +1501,6 @@ class UMAP(BaseEstimator):
                 warn("gradient function is not yet implemented for {} distance metric; "
                      "inverse_transform will be unavailable".format(self.metric))
                 self._inverse_distance_func = None
-        elif self.metric == "precomputed":
-            if self.unique is False:
-                raise ValueError("unique is poorly defined on a precomputed metric")
-            warn("using precomputed metric; transform will be unavailable for new data and inverse_transform "
-                 "will be unavailable for all data")
-            self._inverse_distance_func = None
         else:
             raise ValueError("metric is neither callable nor a recognised string")
 
@@ -1571,9 +1573,6 @@ class UMAP(BaseEstimator):
         self._initial_alpha = self.learning_rate
 
         self._validate_parameters()
-
-        if self.metric == "hellinger" and X.min() < 0:
-            raise ValueError("Metric 'hellinger' does not support negative values")
 
         if self.verbose:
             print(str(self))

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1727,7 +1727,7 @@ class UMAP(BaseEstimator):
                     self._search_graph.transpose()
                 ).tocsr()
 
-                if callable(self._input_distance_func):
+                if callable(self.metric):
                     _distance_func = self._input_distance_func
                 elif self.metric in dist.named_distances:
                     # Choose the right metric based on sparsity
@@ -1735,13 +1735,9 @@ class UMAP(BaseEstimator):
                         _distance_func = sparse.sparse_named_distances[self.metric]
                     else:
                         _distance_func = dist.named_distances[self.metric]
-                elif self.metric == "precomputed":
-                    warn(
-                        "Using precomputed metric; transform will be unavailable for new data"
-                    )
                 else:
                     raise ValueError(
-                        "Metric is neither callable, " + "nor a recognised string"
+                        "Metric is neither callable, nor a recognised string"
                     )
 
                 if self.metric != "precomputed":

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2338,34 +2338,7 @@ class DataFrameUMAP(BaseEstimator):
         self.metrics = metrics
         self.n_neighbors = n_neighbors
         self.output_metric = output_metric
-        if output_metric_kwds is not None:
-            self.output_metric_kwds = output_metric_kwds
-        else:
-            self.output_metric_kwds = {}
-
-        if callable(self.output_metric):
-            self._output_distance_func = self.output_metric
-        elif (
-            self.output_metric in dist.named_distances
-            and self.output_metric in dist.named_distances_with_gradients
-        ):
-            self._output_distance_func = dist.named_distances_with_gradients[
-                self.output_metric
-            ]
-        elif self.output_metric == "precomputed":
-            raise ValueError("output_metric cannnot be 'precomputed'")
-        else:
-            if self.output_metric in dist.named_distances:
-                raise ValueError(
-                    "gradient function is not yet implemented for "
-                    + repr(self.output_metric)
-                    + "."
-                )
-            else:
-                raise ValueError(
-                    "output_metric is neither callable, " + "nor a recognised string"
-                )
-
+        self.output_metric_kwds = output_metric_kwds
         self.n_epochs = n_epochs
         self.init = init
         self.n_components = n_components
@@ -2424,6 +2397,10 @@ class DataFrameUMAP(BaseEstimator):
             self.n_epochs <= 10 or not isinstance(self.n_epochs, int)
         ):
             raise ValueError("n_epochs must be a positive integer " "larger than 10")
+        if self.output_metric_kwds is None:
+            self._output_metric_kwds = {}
+        else:
+            self._output_metric_kwds = self.output_metric_kwds
 
         if callable(self.output_metric):
             self._output_distance_func = self.output_metric


### PR DESCRIPTION
### This PR:
- allows custom distance metrics to be used for fitting, transforming, and inverse-transforming (fixes #366).  This is done by:
  - quickly checking a callable `metric` on the input data to see whether or not it returns a gradient in addition to distance (new `self._check_custom_metric` function)
  - if it does, wrapping it in a `numba.njit`'d function that returns only the distance and using that for `.fit`/`.transform`, while using the full function for `.transform`.
  - if it doesn't, warning upfront that `inverse_transform` will fail, and then explicitly failing if `inverse_transform` is called
  - checking a custom `output_metric` on some simulated `n_components`-dimensional data, and failing with some explanation why
- validates named sparse distance metrics upfront to fail earlier/faster and avoid dynamically updating `UMAP` attributes later
- fixes pre-computing distance matrix for small data using custom metrics that take kwargs
- fixes bug in `inverse_transform` when projecting more data than was used to fit model
- fixes bug in `self._search_graph` construction (fixes #367)
- consolidates a bunch of duplicate param checks and assignments into `self._validate_parameters` and `__init__` (doesn't add any new failure conditions, just fails quicker)
- removes no-longer-needed aliasing of `self.metric_kwargs` (`self._metric_kwargs`)
- removes some other no-longer-needed aliasing of attributes in `.transform` and `.inverse_transform`
- adds some new file types to `.gitignore` (+ some info)
- all changes to files under `docs` and `examples`, and in `umap/plot.py` are due to running `black`

### This PR _doesn't_:
- Implement these new features in the `DataFrameUMAP` class (which currently requires that metrics be named distance functions)
- alter the outward-facing API in any way (to the best of my knowledge)
- update docs to reflect new features (e.g., noting that callable `metric`s should return a tuple of (distance, gradient) if the user wants to be able to use the `inverse_transform` method)
- add any new tests for the new features (though they're largely covered by the existing ones)
- handle the case where a user: 1) has `pynndescent` installed and wants to use it, 2) tries to use `.fit` on a sparse matrix, and 3) passes a custom `metric` function takes some keyword arguments.  This is because `pynndescent` [doesn't accept callable metrics](https://github.com/lmcinnes/pynndescent/blob/13cf8e0a9f60741e4c1847a5447648fc4c1cae8d/pynndescent/pynndescent_.py#L933-L948) for `pynndescent.sparse_nnd.nn_descent`.  Other than this specific combination of circumstances, everything seems to work fine as far as I can tell.