### PR TITLE
check before reshaping labels to 2D

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1842,6 +1842,8 @@ class UMAP(BaseEstimator):
                     metric_scale=scale,
                 )
             else:
+                if len(y_.shape) == 1:
+                    y_ = y_.reshape(-1, 1)
                 if self.target_n_neighbors == -1:
                     target_n_neighbors = self._n_neighbors
                 else:
@@ -1851,13 +1853,13 @@ class UMAP(BaseEstimator):
                 if y.shape[0] < 4096:
                     try:
                         ydmat = pairwise_distances(
-                            y_[np.newaxis, :].T,
+                            y_,
                             metric=self.target_metric,
                             **self._target_metric_kwds
                         )
                     except (TypeError, ValueError):
                         ydmat = dist.pairwise_special_metric(
-                            y_[np.newaxis, :].T,
+                            y_,
                             metric=self.target_metric,
                             kwds=self._target_metric_kwds,
                         )
@@ -1878,7 +1880,7 @@ class UMAP(BaseEstimator):
                 else:
                     # Standard case
                     target_graph, target_sigmas, target_rhos = fuzzy_simplicial_set(
-                        y_[np.newaxis, :].T,
+                        y_,
                         target_n_neighbors,
                         random_state,
                         self.target_metric,

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1853,7 +1853,8 @@ class UMAP(BaseEstimator):
                 if y.shape[0] < 4096:
                     try:
                         ydmat = pairwise_distances(
-                            y_, metric=self.target_metric, **self._target_metric_kwds
+                            y_, metric=self.target_metric,
+                            **self._target_metric_kwds
                         )
                     except (TypeError, ValueError):
                         ydmat = dist.pairwise_special_metric(
@@ -2182,8 +2183,9 @@ class UMAP(BaseEstimator):
             warn(
                 "Inverse transform works best with low dimensional embeddings."
                 " Results may be poor, or this approach to inverse transform"
-                " may fail altogether! If you need a high dimensional latent space"
-                " and inverse transform operations consider using an autoencoder."
+                " may fail altogether! If you need a high dimensional latent"
+                " space and inverse transform operations consider using an"
+                " autoencoder."
             )
 
         X = check_array(X, dtype=np.float32, order="C")

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1853,9 +1853,7 @@ class UMAP(BaseEstimator):
                 if y.shape[0] < 4096:
                     try:
                         ydmat = pairwise_distances(
-                            y_,
-                            metric=self.target_metric,
-                            **self._target_metric_kwds
+                            y_, metric=self.target_metric, **self._target_metric_kwds
                         )
                     except (TypeError, ValueError):
                         ydmat = dist.pairwise_special_metric(
@@ -2181,10 +2179,12 @@ class UMAP(BaseEstimator):
         elif self._inverse_distance_func is None:
             raise ValueError("Inverse transform not available for given metric.")
         elif self.n_components >= 8:
-            warn("Inverse transform works best with low dimensional embeddings."
-                 " Results may be poor, or this approach to inverse transform"
-                 " may fail altogether! If you need a high dimensional latent space"
-                 " and inverse transform operations consider using an autoencoder.")
+            warn(
+                "Inverse transform works best with low dimensional embeddings."
+                " Results may be poor, or this approach to inverse transform"
+                " may fail altogether! If you need a high dimensional latent space"
+                " and inverse transform operations consider using an autoencoder."
+            )
 
         X = check_array(X, dtype=np.float32, order="C")
         random_state = check_random_state(self.transform_seed)


### PR DESCRIPTION
## Problem
When trying to do supervised embedding, using multi-dimension continuous variables, the error below was raised. The current code was assuming labels were single dimension, and always adding a new axis. 

## Solution
Check before reshaping labels

### Error

```
Traceback (most recent call last):
  File "$COND_ENV/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "$COND_ENV/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/ajtritt/projects/exabiome/exabiome.git/src/exabiome/response/umap.py", line 108, in <module>
    n_neighbors=args.n_neighbors)
  File "/Users/ajtritt/projects/exabiome/exabiome.git/src/exabiome/response/umap.py", line 40, in run_umap
    emb = umap.fit_transform(dist, y=labels)
  File "$PATH_TO_UMAP/umap.git/umap/umap_.py", line 1598, in fit_transform
    self.fit(X, y)
  File "$PATH_TO_UMAP/umap.git/umap/umap_.py", line 1505, in fit
    **self._target_metric_kwds
  File "$COND_ENV/lib/python3.7/site-packages/sklearn/metrics/pairwise.py", line 1749, in pairwise_distances
    return _parallel_pairwise(X, Y, func, n_jobs, **kwds)
  File "$COND_ENV/lib/python3.7/site-packages/sklearn/metrics/pairwise.py", line 1348, in _parallel_pairwise
    return func(X, Y, **kwds)
  File "$COND_ENV/lib/python3.7/site-packages/sklearn/metrics/pairwise.py", line 262, in euclidean_distances
    X, Y = check_pairwise_arrays(X, Y)
  File "$COND_ENV/lib/python3.7/site-packages/sklearn/metrics/pairwise.py", line 137, in check_pairwise_arrays
    estimator=estimator)
  File "$COND_ENV/lib/python3.7/site-packages/sklearn/utils/validation.py", line 558, in check_array
    % (array.ndim, estimator_name))
ValueError: Found array with dim 3. check_pairwise_arrays expected <= 2.
```