### PR TITLE
Updating plot.py import error message to remove seaborn and add colorcet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ configuration = {
         "tbb >= 2019.0",
     ],
     "extras_require": {
-        "plot": ["matplotlib", "datashader", "bokeh", "holoviews", "seaborn"],
+        "plot": ["matplotlib", "datashader", "bokeh", "holoviews", "colorcet"],
         "performance": ["pynndescent >= 0.4"],
     },
     "ext_modules": [],

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -20,16 +20,16 @@ except ImportError:
     warn(
         """The umap.plot package requires extra plotting libraries to be installed.
     You can install these via pip using
-    
+
     pip install umap-learn[plot]
-    
+
     or via conda using
-    
-    conda install seaborn datashader bokeh holoviews
+
+    conda install datashader bokeh holoviews colorcet
     """
     )
     raise ImportError(
-        "umap.plot requires matplotlib, seaborn, datashader and holoviews to be "
+        "umap.plot requires matplotlib, datashader, colorcet and holoviews to be "
         "installed"
     ) from None
 


### PR DESCRIPTION
Fixes #390 .

I've updated the error messge for plot.py as well as changing the extra requirements in setup.py.

With that said, the code in `examples` *do* use seaborn. If it makes sense to include `seaborn` in the setup file for these, I can add it back.