### PR TITLE
Patch init import to allow for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 .idea/vcs.xml
 .idea/workspace.xml
 .idea/dictionaries
+.idea/other.xml
 
 # Mac Finder layout
 .DS_Store

--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -5,4 +5,7 @@ import numba
 
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("umap-learn").version
+try:
+    __version__ = pkg_resources.get_distribution("umap-learn").version
+except pkg_resources.DistributionNotFound:
+    __version__ = '0.4-dev'

--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -8,4 +8,4 @@ import pkg_resources
 try:
     __version__ = pkg_resources.get_distribution("umap-learn").version
 except pkg_resources.DistributionNotFound:
-    __version__ = '0.4-dev'
+    __version__ = "0.4-dev"


### PR DESCRIPTION
This is very simple PR, suggesting two changes to to ease the local dev without the need to actually install `umap-learn` in a local env. 

The PR brings two changes:
- modify `umap.__init__.py` to allow working on a dev local version (more on this below)

- including in the `.gitignore` file the `other.xml` idea file - also non-stylistic and so to be ignored.

### The Issue when importing `umap` in a local dev environment

When importing `umap`, the `__version__` variable is automatically derived from `pkg_resources`.
This does not work without installing the package. 

### The (simple and silly) Solution

Catching the exception and manually setting up the version. 
As far as I can see, this won't interfere in any case with normally setup package in a virtual environment.