### PR TITLE
fixed mnist.loader import statement

### DIFF
--- a/doc/supervised.rst
+++ b/doc/supervised.rst
@@ -15,7 +15,7 @@ seaborn for plotting.
 .. code:: python3
 
     import numpy as np
-    from mnist import MNIST
+    from mnist.loader import MNIST
     import matplotlib.pyplot as plt
     %matplotlib inline
     import seaborn as sns


### PR DESCRIPTION
In the documentation, on the supervised clustering page, the example has the following statement to import the fashion MNIST dataset:

```
from mnist import MNIST
```

I believe this is an error, and it should be

```
from mnist.loader import MNIST
```

This is the only change. 