### PR TITLE
Add text search widget to umap.plot.interactive to highlight matching points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,14 @@ configuration = {
         "tbb",
     ],
     "extras_require": {
-        "plot": ["pandas", "matplotlib", "datashader", "bokeh",
-                 "holoviews", "colorcet"],
+        "plot": [
+            "pandas",
+            "matplotlib",
+            "datashader",
+            "bokeh",
+            "holoviews",
+            "colorcet",
+        ],
         "performance": ["pynndescent >= 0.4"],
     },
     "ext_modules": [],

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1388,8 +1388,7 @@ def interactive(
         else:
             tooltips = None
 
-        if interactive_text_search:
-            data['alpha'] = 1
+        data['alpha'] = 1
 
         # bpl.output_notebook(hide_banner=True) # this doesn't work for non-notebook use
         data_source = bpl.ColumnDataSource(data)

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1407,52 +1407,54 @@ def interactive(
 
         plot.grid.visible = False
         plot.axis.visible = False
-        text_input = TextInput(value="", title="Search:")
 
-        callback = CustomJS(args=dict(source=data_source,
-                                      matching_alpha=interactive_text_search_alpha_match,
-                                      non_matching_alpha=interactive_text_search_alpha_miss,
-                                      search_columns=interactive_text_search_columns),
-                            code="""
-            var data = source.data;
-            var text_search = cb_obj.value;
+        if interactive_text_search:
+            text_input = TextInput(value="", title="Search:")
 
-            // If no search columns are provided, search all columns in the data source
-            var search_columns_dict = {}
-            if (search_columns===null){
-                for (var col in data){
-                    search_columns_dict[col] = col
-                }    
-            }else{
-                for (var col in search_columns){
-                    search_columns_dict[col] = search_columns[col]
-                }
-            }
-            
-            console.log(search_columns_dict);
-
-            // Loop over columns and values
-            // If there is no match for any column for a given row, change the alpha value
-            var string_match = false;
-            for (var i = 0; i < data.x.length; i++) {
-                string_match = false
-                for (var j in search_columns_dict) {
-                    if (String(data[search_columns_dict[j]][i]).includes(text_search) ) {
-                        string_match = true
+            callback = CustomJS(args=dict(source=data_source,
+                                          matching_alpha=interactive_text_search_alpha_match,
+                                          non_matching_alpha=interactive_text_search_alpha_miss,
+                                          search_columns=interactive_text_search_columns),
+                                code="""
+                var data = source.data;
+                var text_search = cb_obj.value;
+    
+                // If no search columns are provided, search all columns in the data source
+                var search_columns_dict = {}
+                if (search_columns===null){
+                    for (var col in data){
+                        search_columns_dict[col] = col
+                    }    
+                }else{
+                    for (var col in search_columns){
+                        search_columns_dict[col] = search_columns[col]
                     }
                 }
-                if (string_match){
-                    data['alpha'][i] = matching_alpha
-                }else{
-                    data['alpha'][i] = non_matching_alpha
+                
+                console.log(search_columns_dict);
+    
+                // Loop over columns and values
+                // If there is no match for any column for a given row, change the alpha value
+                var string_match = false;
+                for (var i = 0; i < data.x.length; i++) {
+                    string_match = false
+                    for (var j in search_columns_dict) {
+                        if (String(data[search_columns_dict[j]][i]).includes(text_search) ) {
+                            string_match = true
+                        }
+                    }
+                    if (string_match){
+                        data['alpha'][i] = matching_alpha
+                    }else{
+                        data['alpha'][i] = non_matching_alpha
+                    }
                 }
-            }
-            source.change.emit();
-        """)
+                source.change.emit();
+            """)
 
-        text_input.js_on_change('value', callback)
+            text_input.js_on_change('value', callback)
 
-        plot = column(text_input, plot)
+            plot = column(text_input, plot)
 
         # bpl.show(plot)
     else:
@@ -1497,5 +1499,6 @@ def interactive(
                 width=width,
                 height=height,
             )
+            
 
     return plot

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1187,7 +1187,7 @@ def interactive(
     subset_points=None,
     interactive_text_search=False,
     interactive_text_search_columns=None,
-    interactive_text_search_alpha_contrast=0.95
+    interactive_text_search_alpha_contrast=0.95,
 ):
     """Create an interactive bokeh plot of a UMAP embedding.
     While static plots are useful, sometimes a plot that
@@ -1375,8 +1375,6 @@ def interactive(
         if hover_data is not None:
             hover_data = hover_data[subset_points]
 
-
-
     if points.shape[0] <= width * height // 10:
 
         if hover_data is not None:
@@ -1388,7 +1386,7 @@ def interactive(
         else:
             tooltips = None
 
-        data['alpha'] = 1
+        data["alpha"] = 1
 
         # bpl.output_notebook(hide_banner=True) # this doesn't work for non-notebook use
         data_source = bpl.ColumnDataSource(data)
@@ -1399,7 +1397,14 @@ def interactive(
             tooltips=tooltips,
             background_fill_color=background,
         )
-        plot.circle(x="x", y="y", source=data_source, color=colors, size=point_size, alpha="alpha")
+        plot.circle(
+            x="x",
+            y="y",
+            source=data_source,
+            color=colors,
+            size=point_size,
+            alpha="alpha",
+        )
 
         plot.grid.visible = False
         plot.axis.visible = False
@@ -1407,11 +1412,14 @@ def interactive(
         if interactive_text_search:
             text_input = TextInput(value="", title="Search:")
 
-            callback = CustomJS(args=dict(source=data_source,
-                                          matching_alpha=interactive_text_search_alpha_contrast,
-                                          non_matching_alpha=1-interactive_text_search_alpha_contrast,
-                                          search_columns=interactive_text_search_columns),
-                                code="""
+            callback = CustomJS(
+                args=dict(
+                    source=data_source,
+                    matching_alpha=interactive_text_search_alpha_contrast,
+                    non_matching_alpha=1 - interactive_text_search_alpha_contrast,
+                    search_columns=interactive_text_search_columns,
+                ),
+                code="""
                 var data = source.data;
                 var text_search = cb_obj.value;
                 
@@ -1446,9 +1454,10 @@ def interactive(
                     }
                 }
                 source.change.emit();
-            """)
+            """,
+            )
 
-            text_input.js_on_change('value', callback)
+            text_input.js_on_change("value", callback)
 
             plot = column(text_input, plot)
 
@@ -1461,8 +1470,7 @@ def interactive(
             )
         if interactive_text_search:
             warn(
-                "Too many points for text search."
-                "Sorry; try subssampling your data."
+                "Too many points for text search." "Sorry; try subssampling your data."
             )
         hv.extension("bokeh")
         hv.output(size=300)
@@ -1500,6 +1508,5 @@ def interactive(
                 width=width,
                 height=height,
             )
-            
 
     return plot

--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -5,6 +5,7 @@ import numpy as np
 from sklearn.cluster import KMeans
 from sklearn.metrics import adjusted_rand_score
 from sklearn.neighbors import KDTree
+
 try:
     # works for sklearn>=0.22
     from sklearn.manifold import trustworthiness

--- a/umap/tests/test_umap_trustworthiness.py
+++ b/umap/tests/test_umap_trustworthiness.py
@@ -2,6 +2,7 @@ from umap import UMAP
 from sklearn.datasets import make_blobs
 from nose.tools import assert_greater_equal
 import numpy as np
+
 try:
     # works for sklearn>=0.22
     from sklearn.manifold import trustworthiness


### PR DESCRIPTION
It's often useful to be able to filter/highlight ponts in a UMAP plot based on features of the original data. This functionality is implemented in this pull request.

By default, the behaviour is business as usual. But if `interactive_text_search` is set to True, a Bokeh widget is exposed just above the umap interactive plot and by default all columns in the bokeh data source can be searched. Points matching the search have their alpha (transparency) updated to interactive_text_search_alpha_contrast (default 0.95), and those that don't to (1-interactive_text_search_alpha_contrast) (0.05 by default)

The final parameter is `interactive_text_search_columns`, which lets users search a subset of columns in the data source. All columns in hover_data are available for searching as well as ['x','y','alpha','index','color'] and 'label' if there is one.

Highlighting is done via custom javascript as described here: https://docs.bokeh.org/en/latest/docs/user_guide/interaction/callbacks.html