### PR TITLE
Fixed typos and minor rephrasing in the examples and user guide

### DIFF
--- a/doc/basic_usage.rst
+++ b/doc/basic_usage.rst
@@ -248,7 +248,7 @@ then returns the transformed data as a numpy array.
 The result is an array with 334 samples, but only two feature columns
 (instead of the four we started with). This is because, by default, UMAP
 reduces down to 2D. Each row of the array is a 2-dimensional
-representation of the corresponding flower. Thus we can plot the
+representation of the corresponding penguin. Thus we can plot the
 ``embedding`` as a standard scatterplot and color by the target array
 (since it applies to the transformed data which is in the same order as
 the original).
@@ -386,7 +386,7 @@ is not going to be sufficient for this data.
 
 In contrast we can try using UMAP again. It works exactly as before:
 construct a model, train the model, and then look at the transformed
-data. TO demonstrate more of UMAP we'll go about it differently this
+data. To demonstrate more of UMAP we'll go about it differently this
 time and simply use the ``fit`` method rather than the ``fit_transform``
 approach we used for Penguins.
 

--- a/doc/clustering.rst
+++ b/doc/clustering.rst
@@ -104,8 +104,8 @@ out UMAP embedded data by cluster membership.
 This is not really the result we were looking for (though it does expose
 interesting properties of how K-Means chooses clusters in high
 dimensional space, and how UMAP unwraps manifolds by finding manifold
-boundaries). While K-Means gets some cases correct -- the two clusters
-are the far right are mostly correct, most of the rest of the data looks
+boundaries). While K-Means gets some cases correct, such as the two clusters
+on the right side which are mostly correct, most of the rest of the data looks
 somewhat arbitrarily carved up among the remaining clusters. We can put
 this impression to the test by evaluating the adjusted Rand score and
 adjusted mutual information for this clustering as compared with the
@@ -149,7 +149,7 @@ poorly with the dimensionality of the data it will work on.
 
 We can now inspect the results. Before we do, however, it should be
 noted that one of the features of HDBSCAN is that it can refuse to
-cluster some points and classify the as "noise". To visualize this
+cluster some points and classify them as "noise". To visualize this
 aspect we will color points that were classified as noise gray, and then
 color the remaining points according to the cluster membership.
 
@@ -173,7 +173,7 @@ color the remaining points according to the cluster membership.
 
 
 This looks somewhat underwhelming. It meets HDBSCAN's approach of "not
-being wrong" by simply refusing the classify the majority of the data.
+being wrong" by simply refusing to classify the majority of the data.
 The result is a clustering that almost certainly fails to recover all
 the labels. We can verify this by looking at the clustering validation
 scores.
@@ -356,7 +356,7 @@ quality measures as before.
 
 
 
-Where before HDBSCAN performed very poorly, we now have score of 0.9 or
+Where before HDBSCAN performed very poorly, we now have scores of 0.9 or
 better. This is because we actually clustered far more of the data. As
 before we can also look at how the clustering did on just the data that
 HDBSCAN was confident in clustering.
@@ -403,6 +403,6 @@ techniques. That's not bad for an approach that is simply viewing the
 data as arbitrary 784 dimensional vectors.
 
 Hopefully this has outlined how UMAP can be beneficial for clustering.
-As with all thing care must be taken, but clearly UMAP can provide
+As with all things care must be taken, but clearly UMAP can provide
 significantly better clustering results when used judiciously.
 

--- a/doc/document_embedding.rst
+++ b/doc/document_embedding.rst
@@ -7,12 +7,12 @@ dataset <http://qwone.com/~jason/20Newsgroups/>`__ which is a collection
 of forum posts labelled by topic. We are going to embed these documents
 and see that similar documents (i.e. posts in the same subforum) will
 end up close together. You can use this embedding for other downstream
-tasks such as visualizing your corpus or run a clustering algorithm
+tasks, such as visualizing your corpus, or run a clustering algorithm
 (e.g. HDBSCAN). We will use a bag of words model and use UMAP on the
 count vectors as well as the TF-IDF vectors.
 
 
-To start with let's load the relevant libraries. **This requires UMAP version >= 0.4.0**
+To start with let's load the relevant libraries. **This requires UMAP version >= 0.4.0.**
 
 .. code:: python3
 
@@ -232,7 +232,7 @@ distributions.
     Wall time: 2min 3s
 
 
-Now we have an embedding of 18846x2
+Now we have an embedding of 18846x2.
 
 .. code:: python3
 
@@ -244,8 +244,9 @@ Now we have an embedding of 18846x2
     (18846, 2)
 
 
-Let’s plot the embedding. If running this in a notebook, you should use the interactive plotting method as it let's you hover over
-your points and see what category they belong to.
+Let’s plot the embedding. If you are running this in a notebook, you should use the
+interactive plotting method as it let's you hover over your points and see what
+category they belong to.
 
 .. code:: python3
 
@@ -268,9 +269,9 @@ Using TF-IDF
 We will now do the same pipeline with the only change being the use of
 `TF-IDF <https://en.wikipedia.org/wiki/Tf%E2%80%93idf>`__ weighting.
 TF-IDF gives less weight to words that appear frequently across a large
-number of documents since they are more popular in general. It higher
-weight to words that appear frequently in a smaller subset of documents
-since they are probably important words for those documents.
+number of documents since they are more popular in general. It asserts
+a higher weight to words that appear frequently in a smaller subset of
+documents since they are probably important words for those documents.
 
 To do the TF-IDF weighting we will use sklearns TfidfVectorizer with the
 same parameters as CountVectorizer above.
@@ -280,7 +281,7 @@ same parameters as CountVectorizer above.
     tfidf_vectorizer = TfidfVectorizer(min_df=5, stop_words='english')
     tfidf_word_doc_matrix = tfidf_vectorizer.fit_transform(dataset.data)
 
-We get a matrix of the same size as before
+We get a matrix of the same size as before:
 
 .. code:: python3
 

--- a/doc/document_embedding.rst
+++ b/doc/document_embedding.rst
@@ -245,7 +245,7 @@ Now we have an embedding of 18846x2.
 
 
 Let’s plot the embedding. If you are running this in a notebook, you should use the
-interactive plotting method as it let's you hover over your points and see what
+interactive plotting method as it lets you hover over your points and see what
 category they belong to.
 
 .. code:: python3

--- a/doc/embedding_space.rst
+++ b/doc/embedding_space.rst
@@ -95,7 +95,7 @@ since that will wrap all the way around the equator. You'll note that
 the scales on the x and y axes of the above plot go well outside the
 ranges :math:`(-\pi, \pi)` and :math:`(0, 2\pi)`, so this isn't the
 right representation of the data. We can, however, use straightforward
-formulas to map this data onto a sphere embedded in 3-space.
+formulas to map this data onto a sphere embedded in 3d-space.
 
 .. code:: python3
 
@@ -104,7 +104,7 @@ formulas to map this data onto a sphere embedded in 3-space.
     z = np.cos(sphere_mapper.embedding_[:, 0])
 
 Now ``x``, ``y``, and ``z`` give 3d coordinates for each embedding point
-that lie on the surface of a sphere. We can visualize this using
+that lies on the surface of a sphere. We can visualize this using
 matplotlib's 3d plotting capabilities, and see that we have in fact
 induced a quite reasonable embedding of the data onto the surface of a
 sphere.
@@ -303,8 +303,8 @@ to devise a means to display some of the extra information contained in
 the extra 3 dimensions providing covariance data. To do this it will be
 helpful to be able to draw ellipses corresponding to super-level sets of
 the PDF of the 2d Gaussian. We can start on this by writing a simple
-function to draw ellipses on a plot accoriding to a position, a with, a
-height, and and angle (since this is the format the embedding computed
+function to draw ellipses on a plot accoriding to a position, a width, a
+height, and an angle (since this is the format the embedding computed
 the data).
 
 .. code:: python3
@@ -387,19 +387,19 @@ translucent.
 
 This lets us see the variation of density of clusters with respect to
 the covariance structure -- some clusters have consistently very tight
-covariance,while others are more spread out (and hence have, in a sense,
+covariance, while others are more spread out (and hence have, in a sense,
 greater associated uncertainty. Of course we still have a degree of
 overplotting even here, and it will become increasingly difficult to
 tune alpha channels to make things visible. Instead what we would want
 is an actual density plot, showing the the density of the sum over all
 of these Gaussians.
 
-To do this we'll need to some functions (which we'll use numba to
-accelerate): the evaluation of the density of a 2d Gaussian at a given
-point; an evaluation of the density of a given point summing over a set
-of several Gaussians; and a function to generate the density for each
-point in some grid (summing only over nearby Gaussians to make this
-naive approach more computable).
+To do this we'll need to define some functions, whose execution will be
+accelerated using numba: the evaluation of the density of a 2d Gaussian
+at a given point; an evaluation of the density of a given point summing
+over a set of several Gaussians; and a function to generate the density
+for each point in some grid (summing only over nearby Gaussians to make
+this naive approach more computable).
 
 .. code:: python3
 
@@ -576,4 +576,4 @@ embedding into non-euclidean spaces. This last example ideally
 highlights the limitations of this approach (we really need a suitable
 parameterisation), and some potential approaches to get around this: we
 can use an alternative parameterisation for the embedding, and then
-transform the data into the the desired representation.
+transform the data into the desired representation.

--- a/doc/exploratory_analysis.rst
+++ b/doc/exploratory_analysis.rst
@@ -43,7 +43,7 @@ viewer Maximilian built for it.
 
 `Structure of Recent Philosophy <https://homepage.univie.ac.at/noichlm94/full/zoom_final/index.html>`__
 
-Thanks to Maximilian Noichl
+Thanks to Maximilian Noichl.
 
 Language, Context, and Geometry in Neural Networks
 --------------------------------------------------
@@ -75,14 +75,14 @@ Google and OpenAI built the activation atlas -- analysing the space of activatio
 of a neural network. Here UMAP provides a means to compress the activation landscape
 down to 2 dimensions for visualization. The result was an impressive interactive paper
 in the Distill journal, providing rich visualizations and new insights into
-thw working of convolutional neural networks.
+the working of convolutional neural networks.
 
 .. image:: images/activation_atlas.png
    :width: 400px
 
 `The Activation Atlas <https://distill.pub/2019/activation-atlas/>`__
 
-Thanks to Shan Carter, Zan Armstrong, Ludwig Schubert, Ian Johnson, and Chris Olah
+Thanks to Shan Carter, Zan Armstrong, Ludwig Schubert, Ian Johnson, and Chris Olah.
 
 Open Syllabus Galaxy
 --------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -23,7 +23,7 @@ this is to use
 `pre-processing tools from scikit-learn <http://scikit-learn.org/stable/modules/preprocessing.html>`_.
 All the advice given there applies as sensible preprocessing
 for UMAP, and since UMAP is scikit-learn compatible you
-can put all of this together into a `scikit-learn pipeline <http://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html>`_
+can put all of this together into a `scikit-learn pipeline <http://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html>`_.
 
 
 Can I cluster the results of UMAP?
@@ -210,7 +210,7 @@ By definition:
 - VAE is a kind of encoder-decoder neural network,
   trained with KLD loss and BCE (or MSE) loss
   to enforce the resulting embedding to be continuous.
-  VAE is and extension of auto-encoder network,
+  VAE is an extension of auto-encoder networks,
   which by design should produce embeddings that are
   not only relevant to actually encoding the data, but are
   also smooth.
@@ -244,7 +244,7 @@ Where can I learn more?
 Successful use-cases
 --------------------
 
-UMAP can be / has been Successfully applied to the following domains:
+UMAP can be / has been successfully applied to the following domains:
 
 - Single cell data visualization in biology;
 - Mapping malware based on behavioural data;

--- a/doc/interactive_viz.rst
+++ b/doc/interactive_viz.rst
@@ -26,7 +26,7 @@ Tensorflow Embedding Projector
 If you just want to explore UMAP embeddings of datasets then the Embedding Projector
 from Tensorflow is a great way to do that. As well as having a good interactive 3D view
 it also has facilities for inspecting and searching labels and tags on the data. By default
-it loads up word2vec vectors, but you can uplod any data you wish. You can then select
+it loads up word2vec vectors, but you can upload any data you wish. You can then select
 the UMAP option among the tabs for embeddings choices (alongside PCA and t-SNE).
 
 .. image:: images/embedding_projector.png
@@ -58,7 +58,7 @@ UMAP Explorer
 -------------
 A great demonstration of building a web based app for interactively exploring a UMAP embedding.
 In this case it provides an exploration of UMAP run on the MNIST digits dataset. Each point in
-the embeddijng is rendered as the digit image, and coloured according to the digit class. Mousing
+the embedding is rendered as the digit image, and coloured according to the digit class. Mousing
 over the images will make them larger and provide a view of the digit in the upper left. You can also pan
 and zoom around the emebdding to get a better understanding of how UMAP has mapped the different styles of
 handwritten digits down to 2 dimensions.
@@ -103,9 +103,9 @@ Thanks to Kostas Stathoulopoulos, Zac Ioannidis and Lilia Villafuerte.
 
 Exploring Fashion MNIST
 -----------------------
-A web based interactive exploration of 3D UMAP embedding ran on the Fashion MNIST dataset. Users can
+A web based interactive exploration of a 3D UMAP embedding ran on the Fashion MNIST dataset. Users can
 freely navigate the 3D space, jumping to a specific image by clicking an image or entering an image id.
-Like Grant Custer's UMAP Explorer, each point is rendered as the the actual image and colored according
+Like Grant Custer's UMAP Explorer, each point is rendered as the actual image and colored according to
 the label. It is also similar to the Tensorflow Embedding Projector, but designed more specifically for
 Fashion MNIST, thus more efficient and capable of showing all the 70k images.
 

--- a/doc/inverse_transform.rst
+++ b/doc/inverse_transform.rst
@@ -4,7 +4,7 @@ Inverse transforms
 
 UMAP has some support for inverse transforms -- generating a high
 dimensional data sample given a location in the low dimensional
-embedding space. To start let's load all the relavent libraries.
+embedding space. To start let's load all the relevant libraries.
 
 .. code:: python3
 
@@ -28,7 +28,7 @@ the MNIST dataset we'll make use of sklearn's ``fetch_openml`` function.
     data, labels = sklearn.datasets.fetch_openml('mnist_784', version=1, return_X_y=True)
 
 Now we need to generate a reduced dimension representation of this data.
-This is straightforward with umap, but in this case rather than using
+This is straightforward with UMAP, but in this case rather than using
 ``fit_transform`` we'll use the fit method so that we can retain the
 trained model for later generating new digits based on samples from the
 embedding space.
@@ -52,9 +52,9 @@ to do this.
 
 This looks much like we would expect. The different digit classes have
 been decently separated. Now we need to create a set of samples in the
-emebdding space to apply the ``inverse_transform`` operation to. To do
+embedding space to apply the ``inverse_transform`` operation to. To do
 this we'll generate a grid of samples linearly interpolating between
-four corner points. To make out selection interesting we'll carefully
+four corner points. To make our selection interesting we'll carefully
 choose the corners to span over the dataset, and sample different digits
 so that we can better see the transitions.
 
@@ -77,7 +77,7 @@ so that we can better see the transitions.
 Now we can apply the ``inverse_transform`` method to this set of test
 points. Each test point is a two dimensional point lying somewhere in
 the embedding space. The ``inverse_transform`` method will convert this
-in to an approximation of the high dimensional representation that would
+into an approximation of the high dimensional representation that would
 have been embedded into such a location. Following the sklearn API this
 is as simple to use as calling the ``inverse_transform`` method of the
 trained model and passing it the set of test points that we want to
@@ -175,8 +175,8 @@ Let's plot the embedding to see what we got as a result:
 
 Again we'll generate a set of test points by making a grid interpolating
 between four corners. As before we'll select the corners so that we can
-stay within the convex hull of the embedding points and ensure nothign
-to strange happens with the inverse transforms.
+stay within the convex hull of the embedding points and ensure nothing
+too strange happens with the inverse transforms.
 
 .. code:: python3
 
@@ -202,7 +202,7 @@ to complete.
 
     inv_transformed_points = mapper.inverse_transform(test_pts)
 
-And now we can use similar code as above to set up out plot of the
+And now we can use similar code as above to set up our plot of the
 embedding with test points overlaid, and the generated images.
 
 .. code:: python3

--- a/doc/outliers.rst
+++ b/doc/outliers.rst
@@ -63,7 +63,7 @@ to existing techniques like LOF.
 
 Now that we have a set of outlier scores we can find the actual outlying
 digit images -- these are the ones with scores equal to -1. Let's
-extract out that data, and check that we got 100 different digit images.
+extract that data, and check that we got 100 different digit images.
 
 .. code:: python3
 
@@ -173,7 +173,7 @@ images this approach found to be particularly strange.
 .. image:: images/outliers_19_0.png
 
 
-In many way this looks to be a *better* result than the original LOF in
+In many ways this looks to be a *better* result than the original LOF in
 the high dimensional space. While the digit images that the high
 dimensional LOF found to be strange were indeed somewhat odd looking,
 many of these digit images are considerably stranger -- significantly
@@ -187,15 +187,15 @@ set: what else might lurk in the dataset?
 
 We can, in fact, potentially improve on this result by tuning the UMAP
 embedding a little for the task of finding outliers. When UMAP combines
-together the different local simplicial sets (see :ref:`how_umap_works`
+together the different local simplicial sets (see :doc:`how_umap_works`
 for more details) the standard approach uses a union, but we could
 instead take an intersection. An intersection ensures that outliers
 remain disconnected, which is certainly beneficial when seeking to find
 outliers. A downside of the intersection is that it tends to break up
 the resulting simplicial set into many disconnected components and a lot
 of the more non-local and global structure is lost, resulting in a lot
-lower quality of embedding. We can, however, interpolate between the
-union and intersection. In UMAP this is given by the
+lower quality of the resulting embedding. We can, however, interpolate 
+between the union and intersection. In UMAP this is given by the
 ``set_op_mix_ratio``, where a value of 0.0 represents an intersection,
 and a value of 1.0 represents a union (the default value is 1.0). By
 setting this to a lower value, say 0.25, we can encourage the embedding

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -34,7 +34,7 @@ representation. To make the 4-dimensional data "visualisable" we will
 generate data uniformly at random from a 4-dimensional cube such that we
 can interpret a sample as a tuple of (R,G,B,a) values specifying a color
 (and translucency). Thus when we plot low dimensional representations
-each point can colored according to its 4-dimensional value. For this we
+each point can be colored according to its 4-dimensional value. For this we
 can use ``numpy``. We will fix a random seed for the sake of
 consistency.
 
@@ -73,7 +73,7 @@ associated 4-dimensional color from the source data.
 
 
 As you can see the result is that the data is placed in 2-dimensional
-space such that points that were nearby in in 4-dimensional space (i.e.
+space such that points that were nearby in 4-dimensional space (i.e.
 are similar colors) are kept close together. Since we drew a random
 selection of points in the color cube there is a certain amount of
 induced structure from where the random points happened to clump up in
@@ -185,7 +185,7 @@ As ``n_neighbors`` increases further more and more focus in placed on
 the overall structure of the data. This results in, with
 ``n_neighbors=200`` a plot where the overall structure (blues, greens,
 and reds; high luminance versus low) is well captured, but at the loss
-of some of the finer local sturcture (individual colors are no longer
+of some of the finer local structure (individual colors are no longer
 necessarily immediately near their closest color match).
 
 This effect well exemplifies the local/global tradeoff provided by
@@ -200,8 +200,8 @@ apart that points are allowed to be in the low dimensional
 representation. This means that low values of ``min_dist`` will result
 in clumpier embeddings. This can be useful if you are interested in
 clustering, or in finer topological structure. Larger values of
-``min_dist`` will prevent UMAP from packing point together and will
-focus instead on the preservation of the broad topological structure
+``min_dist`` will prevent UMAP from packing points together and will
+focus on the preservation of the broad topological structure
 instead.
 
 The default value for ``min_dist`` (as used above) is 0.1. We will look
@@ -250,7 +250,7 @@ As is standard for many ``scikit-learn`` dimension reduction algorithms
 UMAP provides a ``n_components`` parameter option that allows the user
 to determine the dimensionality of the reduced dimension space we will
 be embedding the data into. Unlike some other visualisation algorithms
-such as t-SNE UMAP scales well in embedding dimension, so you can use it
+such as t-SNE, UMAP scales well in the embedding dimension, so you can use it
 for more than just visualisation in 2- or 3-dimensions.
 
 For the purposes of this demonstration (so that we can see the effects
@@ -292,8 +292,7 @@ Here we can see that with more dimensions in which to work UMAP has an
 easier time separating out the colors in a way that respects the
 topological structure of the data.
 
-As mentioned, there is really no requirement to stop at ``n_components``
-at 3. If you are interested in (density based) clustering, or other
+As mentioned, there is really no requirement to stop at ``n_components=3``. If you are interested in (density based) clustering, or other
 machine learning techniques, it can be beneficial to pick a larger
 embedding dimension (say 10, or 50) closer to the the dimension of the
 underlying manifold on which your data lies.
@@ -433,7 +432,7 @@ measures distance in the full HSL space.
         return (a_sat - b_sat)**2 + (a_light - b_light)**2 + (((a_hue - b_hue) % 6) / 6.0)
 
 With such custom metrics in hand we can get UMAP to embed the data using
-those metrics to measure distance between our input data points. Note
+those metrics to measure the distance between our input data points. Note
 that ``numba`` provides significant flexibility in what we can do in
 defining distance functions. Despite this we retain the high performance
 we expect from UMAP even using such custom functions.
@@ -465,7 +464,7 @@ we expect from UMAP even using such custom functions.
 
 
 And here we can see the effects of the metrics quite clearly. The pure
-red channel correctly see the data as living on a one dimensional
+red channel correctly sees the data as living on a one dimensional
 manifold, the hue metric interprets the data as living in a circle, and
 the HSL metric fattens out the circle according to the saturation and
 lightness. This provides a reasonable demonstration of the power and

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -65,19 +65,19 @@ form you can simply pass the trained UMAP model to ``umap.plot.points``:
 
 
 As you can see we immediately get a scatterplot of the UMAP embedding.
-Of note the function automatically selects a point-size based on the
+Note that the function automatically selects a point-size based on the
 data density, and watermarks the image with the UMAP parameters that
 were used (this will include the metric if it is non-standard). The
 function also returns the matplotlib axes object associated to the plot,
 so further matplotlib functions, such as adding titles, axis labels etc.
-can be done by the user if required.
+can be applied by the user if required.
 
 It is common for data passed to UMAP to have an associated set of
 labels, which may have been derived from ground-truth, from clustering,
 or via other means. In such cases it is desirable to be able to color
 the scatterplot according to the labelling. We can do this by simply
 passing the array of label information in with the ``labels`` keyword.
-The ``umap.plot.points`` function will the color the data with a
+The ``umap.plot.points`` function will color the data with a
 categorical colormap according to the labels provided.
 
 .. code:: python3
@@ -183,7 +183,7 @@ actual rendering. Thus, regardless of how much data you have
 interface. You, as a user, don't need to worry about switching to
 plotting with datashader, or how to convert your plotting to its
 slightly different API -- you can just use the same API and trust the
-resuts you get.
+results you get.
 
 .. code:: python3
 
@@ -457,7 +457,7 @@ neighborhood has been more accurately preserved.
 As one might expect the local neighborhood preservation tends to be a
 lot better for those points that had a lower local dimension (as seen in
 the last plot). There is also a tendency for the edges of clusters
-(where there were clear boundaries to be followed) have a better
+(where there were clear boundaries to be followed) to have a better
 preservation of neighborhoods than the centers of the clusters that had
 higher local dimension. Again, this provides a view on which areas of
 the embedding you can have greater trust in, and which regions had to

--- a/doc/reproducibility.rst
+++ b/doc/reproducibility.rst
@@ -14,8 +14,8 @@ Since version 0.4 UMAP also support multi-threading for faster
 performance; when performing optimization this exploits the fact that
 race conditions between the threads are acceptable within certain
 optimization phases. Unfortunately this means that the randomness in
-UMAP output for the multi-threaded case depends not only on the random
-seed input, but also on race conditions between thereads during
+UMAP outputs for the multi-threaded case depends not only on the random
+seed input, but also on race conditions between threads during
 optimization, over which no control can be had. This means that
 multi-threaded UMAP results cannot be explicitly reproduced.
 
@@ -60,7 +60,7 @@ PyNNDescent for nearest neighbor search (UMAP will use it if you have it
 installed) which supports multi-threading as well. The result is a very
 fast fitting to the data that does an effective job of using several
 cores. If you are on a large server with many cores available and don't
-wish to use them *all* (which is the default situtation) you can
+wish to use them *all* (which is the default situation) you can
 currently control the number of cores used by setting the numba
 environment variable ``NUMBA_NUM_THREADS``; see the `numba
 documentation <https://numba.pydata.org/numba-doc/dev/reference/envvars.html#threading-control>`__
@@ -111,7 +111,7 @@ Qualitatively this looks very similar, but a little closer inspection
 will quickly show that the results are actually different between the
 runs. Note that even in versions of UMAP prior to 0.4 this would have
 been the case -- since we fixed no specific random seed, and were thus
-using the current random state of the system which will ntaurally differ
+using the current random state of the system which will naturally differ
 between runs. This is the default behaviour, as is standard with sklearn
 estimators that are stochastic. Rather than having a default random seed
 the user is required to explicitly provide one should they want a
@@ -120,7 +120,7 @@ reproducible result. As noted by Vito Zanotelli
     ... setting a random seed is like signing a waiver "I am aware that
     this is a stochastic algorithm and I have done sufficient tests to
     confirm that my main conclusions are not affected by this
-    randomess".
+    randomness".
 
 With that in mind, let's see what happens if we set an explicit
 ``random_state`` value:
@@ -137,10 +137,10 @@ With that in mind, let's see what happens if we set an explicit
     Wall time: 1min 56s
 
 
-The first thing to note that that this run took signifcantly longer
+The first thing to note that that this run took significantly longer
 (despite having all the functions JIT compiled by numba already). Then
 note that the Wall time and CPU times are now much closer to each other
--- we are not longer exploiting multiple cores to anywhere near the same
+-- we are no longer exploiting multiple cores to anywhere near the same
 degree. This is because by setting a ``random_state`` we are effectively
 turning off any of the multi-threading that does not support explicit
 reproducibility. Let's plot the results:

--- a/doc/scientific_papers.rst
+++ b/doc/scientific_papers.rst
@@ -65,7 +65,7 @@ outliers.
 Dimensionality reduction for visualizing single-cell data using UMAP
 --------------------------------------------------------------------
 An early paper on applying UMAP to single-cell biology data. It looks at
-both gene-expression data and flow-cytometry data, and compares UMAP to
+both, gene-expression data and flow-cytometry data, and compares UMAP to
 t-SNE both in terms of performance and quality of results. This is a good
 introduction to using UMAP for single-cell biology data.
 
@@ -82,8 +82,8 @@ to visualise population structures. This produced some intriguing
 visualizations, and was one of the first of several papers taking
 this visualization approach. It also includes some novel visualizations
 using UMAP projections to 3D as RGB color specifications for
-data points, allowing the UMAP structure ot be visualized in
-geographic maps based on where the samples where drawn from.
+data points, allowing the UMAP structure to be visualized in
+geographic maps based on where the samples were drawn from.
 
 .. image:: images/population_umap.jpg
    :width: 400px

--- a/doc/sparse.rst
+++ b/doc/sparse.rst
@@ -280,7 +280,7 @@ We'll grab both the training set, and the test set for later use.
     news_test = sklearn.datasets.fetch_20newsgroups_vectorized(subset='test')
 
 If we look at the actual data we have pulled back, we'll see that
-sklearn has run a ``CountVectorizer`` and produced the data is sparse
+sklearn has run a ``CountVectorizer`` and produced the data in the sparse
 matrix format.
 
 .. code:: python3
@@ -301,11 +301,11 @@ The value of the sparse matrix format is immediately obvious in this
 case; while there are only 11,000 samples there are 130,000 features! If
 the data were stored in a standard ``numpy`` array we would be using up
 10GB of memory! And most of that memory would simply be storing the
-number zero, over and over again. In sparse matrix format it easily fits
+number zero, over and over again. In the sparse matrix format it easily fits
 in memory on most machines. This sort of dimensionality of data is very
 common with text workloads.
 
-The raw counts are, however, not ideal since common words the "the" and
+The raw counts are, however, not ideal since common words such as "the" and
 "and" will dominate the counts for most documents, while contributing
 very little information about the actual content of the document. We can
 correct for this by using a ``TfidfTransformer`` from sklearn, which

--- a/doc/supervised.rst
+++ b/doc/supervised.rst
@@ -52,7 +52,7 @@ up the train and test sets into one large dataset, normalise the values
         'Bag',
         'Ankle boot']
 
-Next we'll load the ``umap`` library so we can do dimension reduction on
+Next we'll load the ``umap`` library so we can perform dimension reduction on
 this dataset.
 
 .. code:: python3
@@ -64,7 +64,7 @@ UMAP on Fashion MNIST
 
 First we'll just do standard unsupervised dimension reduction using UMAP
 so we have a baseline of what the results look like for later
-comparison. This is simply a matter of instiantiating a :class:`~umap.umap_.UMAP` object (in
+comparison. This is simply a matter of instantiating a :class:`~umap.umap_.UMAP` object (in
 this case setting the :attr:`~umap.umap_.UMAP.n_neighbors` parameter to be 5 -- we are
 interested mostly in very local information), then calling the
 :meth:`~umap.umap_.UMAP.fit_transform` method with the data we wish to reduce. By default
@@ -186,9 +186,9 @@ Using Partial Labelling (Semi-Supervised UMAP)
 What if we only have some of our data labelled, however, and a number of
 items are without labels. Can we still make use of the label information
 we do have? This is now a semi-supervised learning problem, and yes, we
-can work with those cases to. To set up the example we'll mask some of
+can work with those cases too. To set up the example we'll mask some of
 the target information -- we'll do this by using the sklearn standard of
-having unlabelled point be given the label of -1 (such as, for example,
+giving unlabelled points a label of -1 (such as, for example,
 the noise points from a DBSCAN clustering).
 
 .. code:: python3
@@ -336,7 +336,7 @@ the :meth:`~umap.umap_.UMAP.transform` method.
 As you can see we have replicated the layout of the training data,
 including much of the internal structure of the classes. For the most
 part assignment of new points follows the classes well. The greatest
-source of confusion in some t-shirts that ended up in mixed with the
+source of confusion are some t-shirts that ended up mixed with the
 shirts, and some pullovers which are confused with the coats. Given the
 difficulty of the problem this is a good result, particularly when
 compared with current state-of-the-art approaches such as `siamese and

--- a/doc/transform.rst
+++ b/doc/transform.rst
@@ -53,7 +53,7 @@ data for testing, which seems suitable in this case.
 
 Now to get a benchmark idea of what we are looking at let's train a
 couple of different classifiers and then see how well they score on the
-test set. For this example lets try a support vector classifier and a
+test set. For this example let's try a support vector classifier and a
 KNN classifier. Ideally we should be tuning hyper-parameters (perhaps a
 grid search using k-fold cross validation), but for the purposes of this
 simple demo we will simply use default parameters for both classifiers.
@@ -82,7 +82,7 @@ accuracy on the test set.
 
 The result is that the support vector classifier apparently had poor
 hyper-parameters for this case (I expect with some tuning we could build
-a much more accurate mode) and the KNN classifier is doing very well.
+a much more accurate model) and the KNN classifier is doing very well.
 
 The goal now is to make use of UMAP as a preprocessing step that one
 could potentially fit into a pipeline. We will therefore obviously need
@@ -182,7 +182,7 @@ before will suffice.
 The results look like what we should expect; the test data has been
 embedded into two dimensions in exactly the locations we should expect
 (by class) given the embedding of the training data visualised above.
-This means we can now try out of models that were trained on the
+This means we can now try out models that were trained on the
 embedded training data by handing them the newly transformed test set.
 
 .. code:: python3
@@ -209,7 +209,7 @@ part of an sklearn machine learning pipeline.
 Just for fun we can run the same experiments, but this time reduce to
 ten dimensions (where we can no longer visualise). In practice this will
 have little gain in this case -- for the digits dataset two dimensions
-is plenty for UMAP and more dimensions won't help. On the other had for
+is plenty for UMAP and more dimensions won't help. On the other hand for
 more complex datasets where more dimensions may allow for a much more
 faithful embedding it is worth noting that we are not restricted to only
 two dimension.
@@ -239,6 +239,6 @@ two dimension.
 
 And we see that in this case we actually marginally lowered our accuracy
 scores (within the potential noise in such scoring mind you). However
-for more interesting datasets the larger dimensional embedding may have
+for more interesting datasets the larger dimensional embedding might have
 been a significant gain -- it is certainly worth exploring as one of the
 parameters in a grid search across a pipeline that includes UMAP.


### PR DESCRIPTION
Hey,
I fixed some typos/irregularities I found while reading the `Tutorial` and `Examples` sections.

The `benchmarking.rst` file seems to be outdated and replaced by `performance.rst` is that correct (I did not fully really check either yet)? 
The caption for the last figure in `docs/supervised.rst` also seems to be wrong. I think it should be "Test" instead of "Train", I didn't change it yet to remain consistent with the content of the figure itself, I can recompute the figure if you would like.

Thank you for this great project and documentation!
