### PR TITLE
Change default loss_report_frequency for ParametricUMAP

### DIFF
--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -51,7 +51,7 @@ class ParametricUMAP(UMAP):
         parametric_reconstruction=False,
         autoencoder_loss=False,
         reconstruction_validation=None,
-        loss_report_frequency=10,
+        loss_report_frequency=1,
         n_training_epochs=1,
         keras_fit_kwargs={},
         **kwargs


### PR DESCRIPTION
The docs of ParametricUMAP claim a loss_report_frequency of 1, but the parameter is 10 by default. This PR changes the value of the parameter to match the docs.