### PR TITLE
fixes for Numba 0.53.0dev0

### DIFF
--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -33,7 +33,7 @@ def clip(val):
     locals={
         "result": numba.types.float32,
         "diff": numba.types.float32,
-        "dim": numba.types.int32,
+        "dim": numba.types.intp,
     },
 )
 def rdist(x, y):


### PR DESCRIPTION
It seems like previous Numba versions (up to 0.51.2 or 0.52.0) may have
worked 'by accident'. When running umap against a recent
development version of Numba. I receievd a single error of the form:

```
E   numba.core.errors.LoweringError: Failed in nopython mode pipeline (step: nopython mode backend)
E   Storing i64 to ptr of i32 ('dim'). FE type int32
E
E   File "umap/layouts.py", line 52:
E   def rdist(x, y):
E       <source elided>
E       result = 0.0
E       dim = x.shape[0]
E       ^
E
E   During: lowering "dim = static_getitem(value=$8load_attr.2, index=0, index_var=$const10.3, fn=<built-in function getitem>)" at /Users/vhaenel/git/numba-integration-testing/umap/umap/layouts.py (52)
```