### PR TITLE
Fix for column names with whitespace in hoverdata

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1386,7 +1386,7 @@ def interactive(
             tooltip_dict = {}
             for col_name in hover_data:
                 data[col_name] = hover_data[col_name]
-                tooltip_dict[col_name] = "@" + col_name
+                tooltip_dict[col_name] = "@{" + col_name + "}"
             tooltips = list(tooltip_dict.items())
         else:
             tooltips = None


### PR DESCRIPTION
Bokeh requires escaping column names with { } as mentioned https://github.com/bokeh/bokeh/issues/4796 .