### PR TITLE
test suite optimisation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba pandas bokeh holoviews datashader scikit-image nose pytest"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn numba pandas bokeh holoviews datashader scikit-image pytest"
   - activate test-environment
   - pip install "tensorflow>=2.1"
   - pip install -e .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,6 @@ jobs:
         displayName: 'Install package'
 
       - script: |
-          pip install nose
           pip install pytest
           pytest --show-capture=no -v --disable-warnings --junitxml=pytest.xml
         displayName: 'Run tests'
@@ -74,7 +73,6 @@ jobs:
         displayName: 'Install package'
 
       - script: |
-          pip install nose
           pip install pytest
           pytest --show-capture=no -v --disable-warnings --junitxml=pytest.xml
         displayName: 'Run tests'
@@ -113,7 +111,6 @@ jobs:
         displayName: 'Install package'
 
       - script: |
-          pip install nose
           pip install pytest
           pytest --show-capture=no -v --disable-warnings --junitxml=pytest.xml
         displayName: 'Run tests'
@@ -147,7 +144,6 @@ jobs:
           pip install -e .
           pip install .[plot]
           pip install .[parametric_umap]
-          pip install nose
           pip install pytest
           pip install pytest-cov
           pip install coveralls

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -38,19 +38,19 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
   # Configure the conda environment and put it in the path using the
   # provided versions
-#  conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+#  conda create -n testenv --yes python=$PYTHON_VERSION pip \
 #        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION numba=$NUMBA_VERSION scikit-learn \
 #        pytest "tensorflow-mkl>=2.2.0"
   if [ $TRAVIS_OS_NAME = 'osx' ]; then
     conda create -q -n testenv --yes python=$PYTHON_VERSION numpy scipy scikit-learn \
-          numba nose pytest pandas
+          numba pytest pandas
 #    pip install bokeh
 #    pip install datashader
 #    pip install holoviews
     conda install --yes "tensorflow>=2.0.0"
   else
     conda create -q -n testenv --yes python=$PYTHON_VERSION numpy scipy scikit-learn \
-          numba pandas bokeh holoviews datashader scikit-image nose pytest \
+          numba pandas bokeh holoviews datashader scikit-image pytest \
           "tensorflow-mkl>=2.2.0"
   fi
 

--- a/umap/tests/conftest.py
+++ b/umap/tests/conftest.py
@@ -9,7 +9,8 @@ from sklearn.datasets import load_iris
 from umap import UMAP, AlignedUMAP
 
 # Globals, used for all the tests
-np.random.seed(42)
+SEED = 189212  # 0b101110001100011100
+np.random.seed(SEED)
 
 
 # Spatial and Binary Data

--- a/umap/tests/test_aligned_umap.py
+++ b/umap/tests/test_aligned_umap.py
@@ -2,9 +2,7 @@ from umap import AlignedUMAP
 from sklearn.metrics import pairwise_distances
 from sklearn.cluster import KMeans
 import numpy as np
-from nose.tools import assert_greater_equal, assert_raises
 from sklearn.metrics import adjusted_rand_score
-from numpy.testing import assert_array_almost_equal
 
 # ===============================
 # Test AlignedUMAP on sliced iris
@@ -25,7 +23,7 @@ def test_neighbor_local_neighbor_accuracy(aligned_iris, aligned_iris_model):
         true_nn = np.argsort(data_dmat, axis=1)[:, :10]
         embd_dmat = pairwise_distances(aligned_iris_model.embeddings_[i])
         embd_nn = np.argsort(embd_dmat, axis=1)[:, :10]
-        assert_greater_equal(nn_accuracy(true_nn, embd_nn), 0.65)
+        assert nn_accuracy(true_nn, embd_nn) >= 0.65
 
 
 def test_local_clustering(aligned_iris, aligned_iris_model):
@@ -34,12 +32,12 @@ def test_local_clustering(aligned_iris, aligned_iris_model):
     embd = aligned_iris_model.embeddings_[1]
     clusters = KMeans(n_clusters=2).fit_predict(embd)
     ari = adjusted_rand_score(target[1], clusters)
-    assert_greater_equal(ari, 0.75)
+    assert ari >= 0.75
 
     embd = aligned_iris_model.embeddings_[3]
     clusters = KMeans(n_clusters=2).fit_predict(embd)
     ari = adjusted_rand_score(target[3], clusters)
-    assert_greater_equal(ari, 0.40)
+    assert ari >= 0.40
 
 
 def test_aligned_update(aligned_iris, aligned_iris_relations):
@@ -52,4 +50,4 @@ def test_aligned_update(aligned_iris, aligned_iris_relations):
         true_nn = np.argsort(data_dmat, axis=1)[:, :10]
         embd_dmat = pairwise_distances(small_aligned_model.embeddings_[i])
         embd_nn = np.argsort(embd_dmat, axis=1)[:, :10]
-        assert_greater_equal(nn_accuracy(true_nn, embd_nn), 0.65)
+        assert nn_accuracy(true_nn, embd_nn) >= 0.65

--- a/umap/tests/test_composite_models.py
+++ b/umap/tests/test_composite_models.py
@@ -1,9 +1,5 @@
 from umap import UMAP
-from sklearn.datasets import make_blobs
-from nose.tools import assert_greater_equal
-from nose import SkipTest
 import pytest
-import numpy as np
 
 try:
     # works for sklearn>=0.22
@@ -28,30 +24,22 @@ def test_composite_trustworthiness(nn_data, iris_model):
     ).fit(data)
     model3 = model1 * model2
     trust = trustworthiness(data, model3.embedding_, 10)
-    assert_greater_equal(
-        trust,
-        0.82,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
     model4 = model1 + model2
     trust = trustworthiness(data, model4.embedding_, 10)
-    assert_greater_equal(
-        trust,
-        0.82,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
     with pytest.raises(ValueError):
-        model5 = model1 + iris_model
+        _ = model1 + iris_model
 
     with pytest.raises(ValueError):
-        model5 = model1 * iris_model
+        _ = model1 * iris_model
 
     with pytest.raises(ValueError):
-        model5 = model1 - iris_model
+        _ = model1 - iris_model
 
 
-@SkipTest
+@pytest.mark.skip(reason="Marked as Skipped test")
 def test_composite_trustworthiness_random_init(nn_data):  # pragma: no cover
     data = nn_data[:50]
     model1 = UMAP(
@@ -62,18 +50,10 @@ def test_composite_trustworthiness_random_init(nn_data):  # pragma: no cover
     ).fit(data)
     model3 = model1 * model2
     trust = trustworthiness(data, model3.embedding_, 10)
-    assert_greater_equal(
-        trust,
-        0.82,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
     model4 = model1 + model2
     trust = trustworthiness(data, model4.embedding_, 10)
-    assert_greater_equal(
-        trust,
-        0.82,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 
 def test_composite_trustworthiness_on_iris(iris):
@@ -85,18 +65,10 @@ def test_composite_trustworthiness_on_iris(iris):
     ).fit(iris.data[:, 2:])
     embedding = (iris_model1 + iris_model2).embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.82,
-        "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust),
-    )
+    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
     embedding = (iris_model1 * iris_model2).embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.82,
-        "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust),
-    )
+    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
 
 
 def test_contrastive_trustworthiness_on_iris(iris):
@@ -108,8 +80,4 @@ def test_contrastive_trustworthiness_on_iris(iris):
     ).fit(iris.data[:, 2:])
     embedding = (iris_model1 - iris_model2).embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.75,
-        "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust),
-    )
+    assert trust >= 0.75, "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)

--- a/umap/tests/test_composite_models.py
+++ b/umap/tests/test_composite_models.py
@@ -24,10 +24,14 @@ def test_composite_trustworthiness(nn_data, iris_model):
     ).fit(data)
     model3 = model1 * model2
     trust = trustworthiness(data, model3.embedding_, 10)
-    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
+    assert (
+        trust >= 0.82
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
     model4 = model1 + model2
     trust = trustworthiness(data, model4.embedding_, 10)
-    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
+    assert (
+        trust >= 0.82
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
     with pytest.raises(ValueError):
         _ = model1 + iris_model
@@ -50,10 +54,14 @@ def test_composite_trustworthiness_random_init(nn_data):  # pragma: no cover
     ).fit(data)
     model3 = model1 * model2
     trust = trustworthiness(data, model3.embedding_, 10)
-    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
+    assert (
+        trust >= 0.82
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
     model4 = model1 + model2
     trust = trustworthiness(data, model4.embedding_, 10)
-    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
+    assert (
+        trust >= 0.82
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 
 def test_composite_trustworthiness_on_iris(iris):
@@ -65,10 +73,14 @@ def test_composite_trustworthiness_on_iris(iris):
     ).fit(iris.data[:, 2:])
     embedding = (iris_model1 + iris_model2).embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
+    assert (
+        trust >= 0.82
+    ), "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
     embedding = (iris_model1 * iris_model2).embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert trust >= 0.82, "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
+    assert (
+        trust >= 0.82
+    ), "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
 
 
 def test_contrastive_trustworthiness_on_iris(iris):
@@ -80,4 +92,6 @@ def test_contrastive_trustworthiness_on_iris(iris):
     ).fit(iris.data[:, 2:])
     embedding = (iris_model1 - iris_model2).embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert trust >= 0.75, "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
+    assert (
+        trust >= 0.75
+    ), "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)

--- a/umap/tests/test_densmap.py
+++ b/umap/tests/test_densmap.py
@@ -1,9 +1,5 @@
 from umap import UMAP
-from sklearn.datasets import make_blobs
-from nose.tools import assert_greater_equal, assert_raises
-from nose import SkipTest
 import pytest
-import numpy as np
 
 try:
     # works for sklearn>=0.22
@@ -27,25 +23,21 @@ def test_densmap_trustworthiness(nn_data):
         output_dens=True,
     ).fit_transform(data)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.75,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.75
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_densmap_trustworthiness_random_init(nn_data):  # pragma: no cover
     data = nn_data[:50]
     embedding = UMAP(
         n_neighbors=10, min_dist=0.01, random_state=42, init="random", densmap=True,
     ).fit_transform(data)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.75,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.75
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 
 def test_densmap_trustworthiness_on_iris(iris):
@@ -54,16 +46,17 @@ def test_densmap_trustworthiness_on_iris(iris):
     ).fit(iris.data)
     embedding = densmap_iris_model.embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.97,
-        "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust),
-    )
-
-    assert_raises(NotImplementedError, densmap_iris_model.transform, iris.data[:10])
-    assert_raises(ValueError, densmap_iris_model.inverse_transform, embedding[:10])
+    assert (
+        trust >= 0.97
+    ), "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
 
     with pytest.raises(NotImplementedError):
-        supervised_densmap_iris_model = UMAP(
+        densmap_iris_model.transform(iris.data[:10])
+
+    with pytest.raises(ValueError):
+        densmap_iris_model.inverse_transform(embedding[:10])
+
+    with pytest.raises(NotImplementedError):
+        _ = UMAP(
             n_neighbors=10, min_dist=0.01, random_state=42, densmap=True, verbose=True,
         ).fit(iris.data, y=iris.target)

--- a/umap/tests/test_plot.py
+++ b/umap/tests/test_plot.py
@@ -3,7 +3,18 @@ import pytest
 import umap
 from unittest import mock
 
-np.random.seed(42)
+# Globals, used for all the tests
+SEED = 189212  # 0b101110001100011100
+np.random.seed(SEED)
+
+try:
+    from umap import plot
+
+    IMPORT_PLOT = True
+except ImportError:
+    IMPORT_PLOT = False
+
+plot_only = pytest.mark.skipif(not IMPORT_PLOT, reason="umap plot not found.")
 
 
 @pytest.fixture(scope="session")
@@ -21,20 +32,10 @@ def test_umap_plot_dependency():
             assert False, "Exception not raised for missing dependency"
 
 
-# Check that the environment is actually setup for testability
-# i.e. all the extra packages have been installed
-def test_umap_plot_testability():
-    try:
-        from umap import plot
-
-        assert True
-    except ImportError:
-        assert False, "Missing dependencies - unable to test!"
-
-
 # These tests requires revision: Refactoring is
 # needed as there is no assertion nor
 # property verification.
+@plot_only
 def test_plot_runs_at_all(mapper, iris, iris_selection):
     from umap import plot as umap_plot
 

--- a/umap/tests/test_plot.py
+++ b/umap/tests/test_plot.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import umap
-from unittest import mock
 
 # Globals, used for all the tests
 SEED = 189212  # 0b101110001100011100
@@ -20,16 +19,6 @@ plot_only = pytest.mark.skipif(not IMPORT_PLOT, reason="umap plot not found.")
 @pytest.fixture(scope="session")
 def mapper(iris):
     return umap.UMAP(n_epochs=100).fit(iris.data)
-
-
-def test_umap_plot_dependency():
-    with mock.patch.dict("sys.modules", pandas=mock.MagicMock()):
-        try:
-            from umap import plot
-        except:
-            assert True
-        else:
-            assert False, "Exception not raised for missing dependency"
 
 
 # These tests requires revision: Refactoring is

--- a/umap/tests/test_umap_metrics.py
+++ b/umap/tests/test_umap_metrics.py
@@ -273,6 +273,7 @@ def test_sparse_correlation(sparse_spatial_data):
 def test_sparse_braycurtis(sparse_spatial_data):
     sparse_spatial_check("braycurtis", sparse_spatial_data)
 
+
 # ---------------------------
 # Sparse Binary Metric Tests
 # ---------------------------

--- a/umap/tests/test_umap_nn.py
+++ b/umap/tests/test_umap_nn.py
@@ -1,15 +1,11 @@
 import numpy as np
-from nose import SkipTest
-from nose.tools import assert_greater_equal, assert_raises
+import pytest
 from numpy.testing import assert_array_almost_equal
-from scipy import sparse
 from sklearn.neighbors import KDTree
 from sklearn.preprocessing import normalize
 
-from umap import distances as dist, sparse as spdist
+from umap import distances as dist
 from umap.umap_ import (
-    INT32_MAX,
-    INT32_MIN,
     nearest_neighbors,
     smooth_knn_dist,
 )
@@ -22,20 +18,15 @@ from umap.umap_ import (
 # nearest_neighbours metric parameter validation
 # -----------------------------------------------
 def test_nn_bad_metric(nn_data):
-    assert_raises(ValueError, nearest_neighbors, nn_data, 10, 42, {}, False, np.random)
+    with pytest.raises(ValueError):
+        nearest_neighbors(nn_data, 10, 42, {}, False, np.random)
 
 
 def test_nn_bad_metric_sparse_data(sparse_nn_data):
-    assert_raises(
-        ValueError,
-        nearest_neighbors,
-        sparse_nn_data,
-        10,
-        "seuclidean",
-        {},
-        False,
-        np.random,
-    )
+    with pytest.raises(ValueError):
+        nearest_neighbors(
+            sparse_nn_data, 10, "seuclidean", {}, False, np.random,
+        )
 
 
 # -------------------------------------------------
@@ -66,60 +57,52 @@ def smooth_knn(nn_data, local_connectivity=1.0):
     return norms
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_nn_descent_neighbor_accuracy(nn_data):  # pragma: no cover
     knn_indices, knn_dists, _ = nearest_neighbors(
         nn_data, 10, "euclidean", {}, False, np.random
     )
     percent_correct = knn(knn_indices, nn_data)
-    assert_greater_equal(
-        percent_correct,
-        0.85,
-        "NN-descent did not get 89% accuracy on nearest neighbors",
-    )
+    assert (
+        percent_correct >= 0.85
+    ), "NN-descent did not get 89% accuracy on nearest neighbors"
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_nn_descent_neighbor_accuracy_low_memory(nn_data):  # pragma: no cover
     knn_indices, knn_dists, _ = nearest_neighbors(
         nn_data, 10, "euclidean", {}, False, np.random, low_memory=True
     )
     percent_correct = knn(knn_indices, nn_data)
-    assert_greater_equal(
-        percent_correct,
-        0.89,
-        "NN-descent did not get 89% accuracy on nearest neighbors",
-    )
+    assert (
+        percent_correct >= 0.89
+    ), "NN-descent did not get 89% accuracy on nearest neighbors"
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_angular_nn_descent_neighbor_accuracy(nn_data):  # pragma: no cover
     knn_indices, knn_dists, _ = nearest_neighbors(
         nn_data, 10, "cosine", {}, True, np.random
     )
     angular_data = normalize(nn_data, norm="l2")
     percent_correct = knn(knn_indices, angular_data)
-    assert_greater_equal(
-        percent_correct,
-        0.85,
-        "NN-descent did not get 89% accuracy on nearest neighbors",
-    )
+    assert (
+        percent_correct >= 0.85
+    ), "NN-descent did not get 89% accuracy on nearest neighbors"
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_sparse_nn_descent_neighbor_accuracy(sparse_nn_data):  # pragma: no cover
     knn_indices, knn_dists, _ = nearest_neighbors(
         sparse_nn_data, 20, "euclidean", {}, False, np.random
     )
     percent_correct = knn(knn_indices, sparse_nn_data.todense())
-    assert_greater_equal(
-        percent_correct,
-        0.75,
-        "Sparse NN-descent did not get 90% accuracy on nearest neighbors",
-    )
+    assert (
+        percent_correct >= 0.75
+    ), "Sparse NN-descent did not get 90% accuracy on nearest neighbors"
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_sparse_nn_descent_neighbor_accuracy_low_memory(
     sparse_nn_data,
 ):  # pragma: no cover
@@ -127,29 +110,24 @@ def test_sparse_nn_descent_neighbor_accuracy_low_memory(
         sparse_nn_data, 20, "euclidean", {}, False, np.random, low_memory=True
     )
     percent_correct = knn(knn_indices, sparse_nn_data.todense())
-    assert_greater_equal(
-        percent_correct,
-        0.85,
-        "Sparse NN-descent did not get 90% accuracy on nearest neighbors",
-    )
+    assert (
+        percent_correct >= 0.85
+    ), "Sparse NN-descent did not get 90% accuracy on nearest neighbors"
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_nn_descent_neighbor_accuracy_callable_metric(nn_data):  # pragma: no cover
     knn_indices, knn_dists, _ = nearest_neighbors(
         nn_data, 10, dist.euclidean, {}, False, np.random
     )
 
     percent_correct = knn(knn_indices, nn_data)
-    assert_greater_equal(
-        percent_correct,
-        0.95,
-        "NN-descent did not get 95% "
-        "accuracy on nearest neighbors with callable metric",
-    )
+    assert (
+        percent_correct >= 0.95
+    ), "NN-descent did not get 95% accuracy on nearest neighbors with callable metric"
 
 
-@SkipTest
+@pytest.mark.skip()
 def test_sparse_angular_nn_descent_neighbor_accuracy(
     sparse_nn_data,
 ):  # pragma: no cover
@@ -158,11 +136,9 @@ def test_sparse_angular_nn_descent_neighbor_accuracy(
     )
     angular_data = normalize(sparse_nn_data, norm="l2").toarray()
     percent_correct = knn(knn_indices, angular_data)
-    assert_greater_equal(
-        percent_correct,
-        0.90,
-        "Sparse NN-descent did not get 90% accuracy on nearest neighbors",
-    )
+    assert (
+        percent_correct >= 0.90
+    ), "Sparse NN-descent did not get 90% accuracy on nearest neighbors"
 
 
 def test_smooth_knn_dist_l1norms(nn_data):

--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -1,5 +1,4 @@
 from umap import UMAP
-from nose.tools import assert_greater_equal
 from scipy import sparse
 import numpy as np
 from sklearn.cluster import KMeans
@@ -25,11 +24,9 @@ except ImportError:
 def test_umap_trustworthiness_on_iris(iris, iris_model):
     embedding = iris_model.embedding_
     trust = trustworthiness(iris.data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.97,
-        "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.97
+    ), "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
 
 
 def test_initialized_umap_trustworthiness_on_iris(iris):
@@ -38,11 +35,9 @@ def test_initialized_umap_trustworthiness_on_iris(iris):
         n_neighbors=10, min_dist=0.01, init=data[:, 2:], n_epochs=200, random_state=42,
     ).fit_transform(data)
     trust = trustworthiness(iris.data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.97,
-        "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.97
+    ), "Insufficiently trustworthy embedding for" "iris dataset: {}".format(trust)
 
 
 def test_umap_trustworthiness_on_sphere_iris(iris,):
@@ -65,12 +60,10 @@ def test_umap_trustworthiness_on_sphere_iris(iris,):
         ]
     ).T
     trust = trustworthiness(iris.data, projected_embedding, 10, metric="cosine")
-    assert_greater_equal(
-        trust,
-        0.80,
-        "Insufficiently trustworthy spherical embedding for iris dataset: {}".format(
-            trust
-        ),
+    assert (
+        trust >= 0.80
+    ), "Insufficiently trustworthy spherical embedding for iris dataset: {}".format(
+        trust
     )
 
 
@@ -83,11 +76,9 @@ def test_umap_transform_on_iris(iris, iris_subset_model, iris_selection):
     embedding = fitter.transform(new_data)
 
     trust = trustworthiness(new_data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.85,
-        "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.85
+    ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
 
 
 def test_umap_transform_on_iris_w_pynndescent(iris, iris_selection):
@@ -104,11 +95,9 @@ def test_umap_transform_on_iris_w_pynndescent(iris, iris_selection):
     embedding = fitter.transform(new_data)
 
     trust = trustworthiness(new_data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.85,
-        "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.85
+    ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
 
 
 def test_umap_transform_on_iris_modified_dtype(iris, iris_subset_model, iris_selection):
@@ -119,11 +108,9 @@ def test_umap_transform_on_iris_modified_dtype(iris, iris_subset_model, iris_sel
     embedding = fitter.transform(new_data)
 
     trust = trustworthiness(new_data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.8,
-        "Insufficiently trustworthy transform for iris dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.8
+    ), "Insufficiently trustworthy transform for iris dataset: {}".format(trust)
 
 
 def test_umap_sparse_transform_on_iris(iris, iris_selection):
@@ -142,11 +129,9 @@ def test_umap_sparse_transform_on_iris(iris, iris_selection):
     embedding = fitter.transform(new_data)
 
     trust = trustworthiness(new_data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.80,
-        "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.80
+    ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
 
 
 # UMAP Clusterability on Iris
@@ -154,7 +139,7 @@ def test_umap_sparse_transform_on_iris(iris, iris_selection):
 def test_umap_clusterability_on_supervised_iris(supervised_iris_model, iris):
     embedding = supervised_iris_model.embedding_
     clusters = KMeans(3).fit_predict(embedding)
-    assert_greater_equal(adjusted_rand_score(clusters, iris.target), 0.95)
+    assert adjusted_rand_score(clusters, iris.target) >= 0.95
 
 
 # UMAP Inverse transform on Iris
@@ -171,6 +156,4 @@ def test_umap_inverse_transform_on_iris(iris, iris_model):
         highd_near_points = highd_tree.query(
             highd_centroid, k=10, return_distance=False
         )
-        assert_greater_equal(
-            np.intersect1d(near_points, highd_near_points[0]).shape[0], 3
-        )
+        assert np.intersect1d(near_points, highd_near_points[0]).shape[0] >= 3

--- a/umap/tests/test_umap_ops.py
+++ b/umap/tests/test_umap_ops.py
@@ -7,7 +7,6 @@ from sklearn.datasets import make_blobs
 from sklearn.cluster import KMeans
 from sklearn.metrics import adjusted_rand_score, pairwise_distances
 from sklearn.preprocessing import normalize
-from nose.tools import assert_equal, assert_less, assert_raises
 from numpy.testing import assert_array_equal
 from umap import UMAP
 from umap.spectral import component_layout
@@ -42,7 +41,7 @@ from scipy.sparse import csr_matrix
 def test_blobs_cluster():
     data, labels = make_blobs(n_samples=500, n_features=10, centers=5)
     embedding = UMAP(n_epochs=100).fit_transform(data)
-    assert_equal(adjusted_rand_score(labels, KMeans(5).fit_predict(embedding)), 1.0)
+    assert adjusted_rand_score(labels, KMeans(5).fit_predict(embedding)) == 1.0
 
 
 # Multi-components Layout
@@ -69,7 +68,7 @@ def test_multi_component_layout():
 
     error = np.sum((true_centroids - embed_centroids) ** 2)
 
-    assert_less(error, 15.0, msg="Multi component embedding to far astray")
+    assert error < 15.0, "Multi component embedding to far astray"
 
 
 # Multi-components Layout
@@ -99,7 +98,7 @@ def test_multi_component_layout_precomputed():
 
     error = np.sum((true_centroids - embed_centroids) ** 2)
 
-    assert_less(error, 15.0, msg="Multi component embedding to far astray")
+    assert error < 15.0, "Multi component embedding to far astray"
 
 
 @pytest.mark.parametrize("num_isolates", [1, 5])
@@ -176,7 +175,8 @@ def test_disconnected_data_precomputed(num_isolates, sparse):
 
 def test_bad_transform_data(nn_data):
     u = UMAP().fit([[1, 1, 1, 1]])
-    assert_raises(ValueError, u.transform, [[0, 0, 0, 0]])
+    with pytest.raises(ValueError):
+        u.transform([[0, 0, 0, 0]])
 
 
 # Transform Stability
@@ -236,7 +236,7 @@ def test_umap_update(iris, iris_subset_model, iris_selection, iris_model):
 
     error = np.sum(np.abs((new_model.graph_ - comparison_graph).data))
 
-    assert_less(error, 1.0)
+    assert error < 1.0
 
 
 # -----------------
@@ -248,7 +248,7 @@ def test_umap_graph_layout():
     graph = model.fit_transform(data)
     assert scipy.sparse.issparse(graph)
     nc, cl = scipy.sparse.csgraph.connected_components(graph)
-    assert_equal(nc, 5)
+    assert nc == 5
 
     new_graph = model.transform(data[:10] + np.random.normal(0.0, 0.1, size=(10, 10)))
     assert scipy.sparse.issparse(graph)

--- a/umap/tests/test_umap_repeated_data.py
+++ b/umap/tests/test_umap_repeated_data.py
@@ -1,6 +1,4 @@
 import numpy as np
-from nose.tools import assert_equal
-
 from umap import UMAP
 
 
@@ -20,14 +18,14 @@ def test_repeated_points_large_sparse_spatial(sparse_spatial_data_repeats):
         n_epochs=20,
         verbose=True,
     ).fit(sparse_spatial_data_repeats)
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 def test_repeated_points_small_sparse_spatial(sparse_spatial_data_repeats):
     model = UMAP(n_neighbors=3, unique=True, n_epochs=20).fit(
         sparse_spatial_data_repeats
     )
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 # Use force_approximation_algorithm in order to test the region
@@ -36,12 +34,12 @@ def test_repeated_points_large_dense_spatial(spatial_repeats):
     model = UMAP(
         n_neighbors=3, unique=True, force_approximation_algorithm=True, n_epochs=50
     ).fit(spatial_repeats)
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 def test_repeated_points_small_dense_spatial(spatial_repeats):
     model = UMAP(n_neighbors=3, unique=True, n_epochs=20).fit(spatial_repeats)
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 # ===================================================
@@ -56,14 +54,14 @@ def test_repeated_points_large_sparse_binary(sparse_binary_data_repeats):
     model = UMAP(
         n_neighbors=3, unique=True, force_approximation_algorithm=True, n_epochs=50
     ).fit(sparse_binary_data_repeats)
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 def test_repeated_points_small_sparse_binary(sparse_binary_data_repeats):
     model = UMAP(n_neighbors=3, unique=True, n_epochs=20).fit(
         sparse_binary_data_repeats
     )
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 # Use force_approximation_algorithm in order to test
@@ -72,13 +70,13 @@ def test_repeated_points_large_dense_binary(binary_repeats):
     model = UMAP(
         n_neighbors=3, unique=True, force_approximation_algorithm=True, n_epochs=20
     ).fit(binary_repeats)
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 def test_repeated_points_small_dense_binary(binary_repeats):
     model = UMAP(n_neighbors=3, unique=True, n_epochs=20).fit(binary_repeats)
-    assert_equal(np.unique(binary_repeats[0:2], axis=0).shape[0], 1)
-    assert_equal(np.unique(model.embedding_[0:2], axis=0).shape[0], 1)
+    assert np.unique(binary_repeats[0:2], axis=0).shape[0] == 1
+    assert np.unique(model.embedding_[0:2], axis=0).shape[0] == 1
 
 
 # ===================================================
@@ -92,4 +90,4 @@ def test_repeated_points_small_dense_binary(binary_repeats):
 # ----------------------------------------------------
 def test_repeated_points_large_n(repetition_dense):
     model = UMAP(n_neighbors=5, unique=True, n_epochs=20).fit(repetition_dense)
-    assert_equal(model._n_neighbors, 3)
+    assert model._n_neighbors == 3

--- a/umap/tests/test_umap_trustworthiness.py
+++ b/umap/tests/test_umap_trustworthiness.py
@@ -1,7 +1,6 @@
 from umap import UMAP
 from sklearn.datasets import make_blobs
 from sklearn.metrics import pairwise_distances
-from nose.tools import assert_greater_equal
 import numpy as np
 import scipy.sparse
 
@@ -23,12 +22,9 @@ except ImportError:
 def test_umap_sparse_trustworthiness(sparse_test_data):
     embedding = UMAP(n_neighbors=10, n_epochs=100).fit_transform(sparse_test_data[:100])
     trust = trustworthiness(sparse_test_data[:100].toarray(), embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.85,
-        "Insufficiently trustworthy embedding for"
-        "sparse test dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.85
+    ), "Insufficiently trustworthy embedding for sparse test dataset: {}".format(trust)
 
 
 def test_umap_trustworthiness_fast_approx(nn_data):
@@ -41,11 +37,9 @@ def test_umap_trustworthiness_fast_approx(nn_data):
         force_approximation_algorithm=True,
     ).fit_transform(data)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.75,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.75
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 
 def test_umap_trustworthiness_random_init(nn_data):
@@ -54,11 +48,9 @@ def test_umap_trustworthiness_random_init(nn_data):
         n_neighbors=10, min_dist=0.01, random_state=42, n_epochs=100, init="random"
     ).fit_transform(data)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.75,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.75
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 
 def test_supervised_umap_trustworthiness():
@@ -67,11 +59,9 @@ def test_supervised_umap_trustworthiness():
         n_neighbors=10, min_dist=0.01, random_state=42, n_epochs=100
     ).fit_transform(data, labels)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.95,
-        "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.95
+    ), "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust)
 
 
 def test_semisupervised_umap_trustworthiness():
@@ -81,11 +71,9 @@ def test_semisupervised_umap_trustworthiness():
         n_neighbors=10, min_dist=0.01, random_state=42, n_epochs=100
     ).fit_transform(data, labels)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.95,
-        "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.95
+    ), "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust)
 
 
 def test_metric_supervised_umap_trustworthiness():
@@ -99,11 +87,9 @@ def test_metric_supervised_umap_trustworthiness():
         random_state=42,
     ).fit_transform(data, labels)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.95,
-        "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.95
+    ), "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust)
 
 
 def test_string_metric_supervised_umap_trustworthiness():
@@ -118,11 +104,9 @@ def test_string_metric_supervised_umap_trustworthiness():
         random_state=42,
     ).fit_transform(data, labels)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.95,
-        "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.95
+    ), "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust)
 
 
 def test_discrete_metric_supervised_umap_trustworthiness():
@@ -136,11 +120,9 @@ def test_discrete_metric_supervised_umap_trustworthiness():
         random_state=42,
     ).fit_transform(data, labels)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.95,
-        "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.95
+    ), "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust)
 
 
 def test_count_metric_supervised_umap_trustworthiness():
@@ -155,11 +137,9 @@ def test_count_metric_supervised_umap_trustworthiness():
         random_state=42,
     ).fit_transform(data, labels)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.95,
-        "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.95
+    ), "Insufficiently trustworthy embedding for" "blobs dataset: {}".format(trust)
 
 
 def test_sparse_precomputed_metric_umap_trustworthiness():
@@ -173,8 +153,6 @@ def test_sparse_precomputed_metric_umap_trustworthiness():
         metric="precomputed",
     ).fit_transform(dmat)
     trust = trustworthiness(data, embedding, 10)
-    assert_greater_equal(
-        trust,
-        0.75,
-        "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust),
-    )
+    assert (
+        trust >= 0.75
+    ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)

--- a/umap/tests/test_umap_validation_params.py
+++ b/umap/tests/test_umap_validation_params.py
@@ -4,7 +4,6 @@
 
 import warnings
 import numpy as np
-from nose.tools import assert_equal, assert_raises
 from sklearn.metrics import pairwise_distances
 import pytest
 import numba
@@ -18,12 +17,14 @@ warnings.filterwarnings("ignore", category=UserWarning)
 
 def test_umap_negative_op(nn_data):
     u = UMAP(set_op_mix_ratio=-1.0)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_too_large_op(nn_data):
     u = UMAP(set_op_mix_ratio=1.5)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_too_large_min_dist(nn_data):
@@ -32,96 +33,116 @@ def test_umap_bad_too_large_min_dist(nn_data):
     # caught and ignored for this test
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=RuntimeWarning)
-        assert_raises(ValueError, u.fit, nn_data)
+        with pytest.raises(ValueError):
+            u.fit(nn_data)
 
 
 def test_umap_negative_min_dist(nn_data):
     u = UMAP(min_dist=-1)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_n_components(nn_data):
     u = UMAP(n_components=-1)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_non_integer_n_components(nn_data):
     u = UMAP(n_components=1.5)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_too_small_n_neighbours(nn_data):
     u = UMAP(n_neighbors=0.5)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_n_neighbours(nn_data):
     u = UMAP(n_neighbors=-1)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_metric(nn_data):
     u = UMAP(metric=45)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_learning_rate(nn_data):
     u = UMAP(learning_rate=-1.5)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_repulsion(nn_data):
     u = UMAP(repulsion_strength=-0.5)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_sample_rate(nn_data):
     u = UMAP(negative_sample_rate=-1)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_init(nn_data):
     u = UMAP(init="foobar")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_numeric_init(nn_data):
     u = UMAP(init=42)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_matrix_init(nn_data):
     u = UMAP(init=np.array([[0, 0, 0], [0, 0, 0]]))
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_n_epochs(nn_data):
     u = UMAP(n_epochs=-2)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_negative_target_n_neighbours(nn_data):
     u = UMAP(target_n_neighbors=1)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_output_metric(nn_data):
     u = UMAP(output_metric="foobar")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(output_metric="precomputed")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(output_metric="hamming")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_haversine_on_highd(nn_data):
     u = UMAP(metric="haversine")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_haversine_embed_to_highd(nn_data):
     u = UMAP(n_components=3, output_metric="haversine")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_too_many_neighbors_warns(nn_data):
@@ -129,55 +150,68 @@ def test_umap_too_many_neighbors_warns(nn_data):
     u.fit(
         nn_data[:100,]
     )
-    assert_equal(u._a, 1.2)
-    assert_equal(u._b, 1.75)
+    assert u._a == 1.2
+    assert u._b == 1.75
 
 
 def test_densmap_lambda(nn_data):
     u = UMAP(densmap=True, dens_lambda=-1.0)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_densmap_var_shift(nn_data):
     u = UMAP(densmap=True, dens_var_shift=-1.0)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_densmap_frac(nn_data):
     u = UMAP(densmap=True, dens_frac=-1.0)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(densmap=True, dens_frac=2.0)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_unique_and_precomputed(nn_data):
     u = UMAP(metric="precomputed", unique=True)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_densmap_bad_output_metric(nn_data):
     u = UMAP(densmap=True, output_metric="haversine")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_n_components(nn_data):
     u = UMAP(n_components=2.3)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(n_components="23")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(n_components=np.float64(2.3))
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_metrics(nn_data):
     u = UMAP(metric="foobar")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(metric=2.75)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(output_metric="foobar")
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(output_metric=2.75)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     # u = UMAP(target_metric="foobar")
     # assert_raises(ValueError, u.fit, nn_data)
     # u = UMAP(target_metric=2.75)
@@ -186,9 +220,11 @@ def test_umap_bad_metrics(nn_data):
 
 def test_umap_bad_n_jobs(nn_data):
     u = UMAP(n_jobs=-2)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
     u = UMAP(n_jobs=0)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_custom_distance_w_grad(nn_data):
@@ -217,23 +253,27 @@ def test_umap_bad_output_metric_no_grad(nn_data):
         return np.sum(np.abs(x - y))
 
     u = UMAP(output_metric=dist1)
-    assert_raises(ValueError, u.fit, nn_data)
+    with pytest.raises(ValueError):
+        u.fit(nn_data)
 
 
 def test_umap_bad_hellinger_data(nn_data):
     u = UMAP(metric="hellinger")
-    assert_raises(ValueError, u.fit, -nn_data)
+    with pytest.raises(ValueError):
+        u.fit(-nn_data)
 
 
 def test_umap_update_bad_params(nn_data):
     dmat = pairwise_distances(nn_data[:100])
     u = UMAP(metric="precomputed", n_epochs=11)
     u.fit(dmat)
-    assert_raises(ValueError, u.update, dmat)
+    with pytest.raises(ValueError):
+        u.update(dmat)
 
     u = UMAP(n_epochs=11)
     u.fit(nn_data[:100], y=np.repeat(np.arange(5), 20))
-    assert_raises(ValueError, u.update, nn_data[100:200])
+    with pytest.raises(ValueError):
+        u.update(nn_data[100:200])
 
 
 def test_umap_fit_data_and_targets_compliant():
@@ -241,16 +281,19 @@ def test_umap_fit_data_and_targets_compliant():
     u = UMAP()
     x = np.random.uniform(0, 1, (256, 10))
     y = np.random.randint(10, size=(257,))
-    assert_raises(ValueError, u.fit, x, y)
+    with pytest.raises(ValueError):
+        u.fit(x, y)
 
     u = UMAP()
     x = np.random.uniform(0, 1, (256, 10))
     y = np.random.randint(10, size=(255,))
-    assert_raises(ValueError, u.fit, x, y)
+    with pytest.raises(ValueError):
+        u.fit(x, y)
 
     u = UMAP()
     x = np.random.uniform(0, 1, (256, 10))
-    assert_raises(ValueError, u.fit, x, [])
+    with pytest.raises(ValueError):
+        u.fit(x, [])
 
 
 def test_umap_fit_instance_returned():
@@ -273,7 +316,9 @@ def test_umap_fit_instance_returned():
 def test_umap_inverse_transform_fails_expectedly(sparse_spatial_data, nn_data):
     u = UMAP(n_epochs=11)
     u.fit(sparse_spatial_data[:100])
-    assert_raises(ValueError, u.inverse_transform, u.embedding_[:10])
+    with pytest.raises(ValueError):
+        u.inverse_transform(u.embedding_[:10])
     u = UMAP(metric="dice", n_epochs=11)
     u.fit(nn_data[:100])
-    assert_raises(ValueError, u.inverse_transform, u.embedding_[:10])
+    with pytest.raises(ValueError):
+        u.inverse_transform(u.embedding_[:10])


### PR DESCRIPTION
This PR aims at optimising the suite of tests included in `umap` to allow for flexible adaptations to different (Python) environments, for what concerns the optional dependencies (i.e. `umap.plot` and `umap.parametric_umap`). 

In details, two main contributions have been implemented: 

- the whole test suites now is fully based on `pytest`, dropping completely `nose` dependency.
- all tests requiring optional packages to be available for the execution are dynamically skipped if those packages are not installed in the environment (e.g. `tensorflow`).

These changes were motivated by the preliminary tests run using the latest RC `numba` version (i.e. `0.53.0rc1`), and *Python 3.9*. Currently `tensorflow` does not support `Python 3.9` yet - due to an incompatibility with `protobuf`(see [Issue #44485](https://github.com/tensorflow/tensorflow/issues/44485). So the test suite now skips automatically the tests on `ParametricUMAP` when using Python 3.9. 

**Other minor changes included in the PR**:

- unused imports and code have been removed from code
- tests for parametric `umap` now includes some basic assertions to test properties of the calculated embeddings (e.g. shape)
- the `moon_dataset` has been re-used as test fixtures and extended to `200` samples
- ParametricUMAP with validation uses half of the original dataset.