### PR TITLE
Fix for metric being mapped to metric name not valid for sklearn.

### DIFF
--- a/umap/spectral.py
+++ b/umap/spectral.py
@@ -7,6 +7,7 @@ import scipy.sparse.csgraph
 
 from sklearn.manifold import SpectralEmbedding
 from sklearn.metrics import pairwise_distances
+from sklearn.metrics.pairwise import _VALID_METRICS as SKLEARN_PAIRWISE_VALID_METRICS
 
 from umap.distances import pairwise_special_metric, SPECIAL_METRICS
 from umap.sparse import SPARSE_SPECIAL_METRICS, sparse_named_distances
@@ -107,7 +108,9 @@ def component_layout(
         else:
             if callable(metric) and scipy.sparse.isspmatrix(data):
                 function_to_name_mapping = {
-                    v: k for k, v in sparse_named_distances.items()
+                    sparse_named_distances[k]: k for k in
+                    set(SKLEARN_PAIRWISE_VALID_METRICS) &
+                    set(sparse_named_distances.keys())
                 }
                 try:
                     metric_name = function_to_name_mapping[metric]


### PR DESCRIPTION
This is a work around for this problem I'm having:

File "/usr/local/lib/python3.8/site-packages/fire/core.py", line 672, in CallAndUpdateTrace
component = fn(*varargs, **kwargs)
File "pipeline.py", line 41, in process_raw_text
doc_to_vec_transform = umap.UMAP(n_components=2, metric='manhattan').fit(word_doc_matrix)
File "/usr/local/lib/python3.8/site-packages/umap/umap.py", line 1965, in fit
self.embedding_ = simplicial_set_embedding(
File "/usr/local/lib/python3.8/site-packages/umap/umap_.py", line 1033, in simplicial_set_embedding
initialisation = spectral_layout(
File "/usr/local/lib/python3.8/site-packages/umap/spectral.py", line 298, in spectral_layout
return multi_component_layout(
File "/usr/local/lib/python3.8/site-packages/umap/spectral.py", line 186, in multi_component_layout
meta_embedding = component_layout(
File "/usr/local/lib/python3.8/site-packages/umap/spectral.py", line 117, in component_layout
distance_matrix = pairwise_distances(
File "/usr/local/lib/python3.8/site-packages/sklearn/utils/validation.py", line 72, in inner_f
return f(**kwargs)
File "/usr/local/lib/python3.8/site-packages/sklearn/metrics/pairwise.py", line 1738, in pairwise_distances
raise ValueError("Unknown metric %s. "
ValueError: Unknown metric taxicab. Valid metrics are ['euclidean', 'l2', 'l1', 'manhattan', 'cityblock', 'braycurtis', 'canberra', 'chebyshev', 'correlation', 'cosine', 'dice', 'hamming', 'jaccard', 'kulsinski', 'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule', 'wminkowski', 'nan_euclidean', 'haversine'], or 'precomputed', or a callable

I ask for metric name manhattan but when it gets down to sklearn module it has changed into taxicab which sklearn doesn't recognise. This happens because the metric names are mapped to functions and then mapped back to names. This isn't a one-to-one mapping so it is possible for the metric name to be different from the one started with. Which means that it can go from a name which is valid for sklearn pairwise_distances to one which isn't.

Probably there is a better way to solve this but my current work around is to just create the inverse mapping with only those names which are valid for sklearn.

Note: A remake of a previous pr that got a bit messy due to rebasing to bringing new changes from master.