### PR TITLE
Fixing flaky test

### DIFF
--- a/umap/tests/test_aligned_umap.py
+++ b/umap/tests/test_aligned_umap.py
@@ -50,4 +50,4 @@ def test_aligned_update(aligned_iris, aligned_iris_relations):
         true_nn = np.argsort(data_dmat, axis=1)[:, :10]
         embd_dmat = pairwise_distances(small_aligned_model.embeddings_[i])
         embd_nn = np.argsort(embd_dmat, axis=1)[:, :10]
-        assert nn_accuracy(true_nn, embd_nn) >= 0.65
+        assert nn_accuracy(true_nn, embd_nn) >= 0.45


### PR DESCRIPTION
The test `test_aligned_update` fails non-deterministically sometimes. This PR fixes this issue.

To find a solution, I collected samples of the accuracy value from several test executions and computed the tail distribution. I computed the extreme percentiles to check how high can the values be. 

```
0.99::0.63
0.999::0.56
0.9999::0.45
```

I selected the 99.99th perc for the fix. I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.