### PR TITLE
Support predicting new points with precomputed distances

### DIFF
--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.cluster import KMeans
 from sklearn.metrics import adjusted_rand_score
 from sklearn.neighbors import KDTree
-from scipy.spatial.distance import cdist, pdist
+from scipy.spatial.distance import cdist, pdist, squareform
 
 try:
     # works for sklearn>=0.22
@@ -139,7 +139,7 @@ def test_umap_sparse_transform_on_iris(iris, iris_selection):
 # ----------------------
 def test_precomputed_transform_on_iris(iris, iris_selection):
     data = iris.data[iris_selection]
-    distance_matrix = pdist(data)
+    distance_matrix = squareform(pdist(data))
 
     fitter = UMAP(
         n_neighbors=10,
@@ -163,7 +163,7 @@ def test_precomputed_transform_on_iris(iris, iris_selection):
 # ----------------------
 def test_precomputed_sparse_transform_on_iris(iris, iris_selection):
     data = iris.data[iris_selection]
-    distance_matrix = sparse.csr_matrix(pdist(data))
+    distance_matrix = sparse.csr_matrix(squareform(pdist(data)))
 
     fitter = UMAP(
         n_neighbors=10,

--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -4,6 +4,7 @@ import numpy as np
 from sklearn.cluster import KMeans
 from sklearn.metrics import adjusted_rand_score
 from sklearn.neighbors import KDTree
+from scipy.spatial.distance import cdist, pdist
 
 try:
     # works for sklearn>=0.22
@@ -131,6 +132,54 @@ def test_umap_sparse_transform_on_iris(iris, iris_selection):
     trust = trustworthiness(new_data, embedding, 10)
     assert (
         trust >= 0.80
+    ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
+
+
+# UMAP precomputed metric transform on iris
+# ----------------------
+def test_precomputed_transform_on_iris(iris, iris_selection):
+    data = iris.data[iris_selection]
+    distance_matrix = pdist(data)
+
+    fitter = UMAP(
+        n_neighbors=10,
+        min_dist=0.01,
+        random_state=42,
+        n_epochs=100,
+        metric='precomputed'
+    ).fit(distance_matrix)
+
+    new_data = iris.data[~iris_selection]
+    new_distance_matrix = cdist(new_data, data)
+    embedding = fitter.transform(new_distance_matrix)
+
+    trust = trustworthiness(new_data, embedding, 10)
+    assert (
+        trust >= 0.85
+    ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
+
+
+# UMAP precomputed metric transform on iris with sparse distances
+# ----------------------
+def test_precomputed_sparse_transform_on_iris(iris, iris_selection):
+    data = iris.data[iris_selection]
+    distance_matrix = sparse.csr_matrix(pdist(data))
+
+    fitter = UMAP(
+        n_neighbors=10,
+        min_dist=0.01,
+        random_state=42,
+        n_epochs=100,
+        metric='precomputed'
+    ).fit(distance_matrix)
+
+    new_data = iris.data[~iris_selection]
+    new_distance_matrix = sparse.csr_matrix(cdist(new_data, data))
+    embedding = fitter.transform(new_distance_matrix)
+
+    trust = trustworthiness(new_data, embedding, 10)
+    assert (
+        trust >= 0.85
     ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
 
 

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2741,6 +2741,8 @@ class UMAP(BaseEstimator):
                 dists = np.full_like(indices, dtype=np.float32, fill_value=-1)
                 for i in range(X.shape[0]):
                     data_indices = np.argsort(X[i].data)
+                    if len(data_indices) < self._n_neighbors:
+                        raise ValueError(f"Need at least n_neighbors ({self.n_neighbors}) distances for each row!")
                     indices[i] = X[i].indices[data_indices[:self._n_neighbors]]
                     dists[i] = X[i].data[data_indices[:self._n_neighbors]]
             else:

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2730,10 +2730,10 @@ class UMAP(BaseEstimator):
         rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
 
         if self.metric == 'precomputed':
-            warn("Transforming new data with precomputed metric."
-                 "We are assuming the input data is a matrix of distances from the new points"
-                 "to the points in the training set. If the input matrix is sparse, it should"
-                 "contain distances from the new points to their nearest neighbours"
+            warn("Transforming new data with precomputed metric. "
+                 "We are assuming the input data is a matrix of distances from the new points "
+                 "to the points in the training set. If the input matrix is sparse, it should "
+                 "contain distances from the new points to their nearest neighbours "
                  "or approximate nearest neighbours in the training set.")
             assert X.shape[1] == self._raw_data.shape[0]
             if scipy.sparse.issparse(X):

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2720,11 +2720,6 @@ class UMAP(BaseEstimator):
                 "Transforming data into an existing embedding not supported for densMAP."
             )
 
-        # if self.metric == "precomputed":
-        #     raise ValueError(
-        #         "Transform  of new data not available for precomputed metric."
-        #     )
-
         # X = check_array(X, dtype=np.float32, order="C", accept_sparse="csr")
         random_state = check_random_state(self.transform_seed)
         rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1755,8 +1755,7 @@ class UMAP(BaseEstimator):
             if self.unique:
                 raise ValueError("unique is poorly defined on a precomputed metric")
             warn(
-                "using precomputed metric; transform will be unavailable for new data and inverse_transform "
-                "will be unavailable for all data"
+                "using precomputed metric; inverse_transform will be unavailable"
             )
             self._input_distance_func = self.metric
             self._inverse_distance_func = None


### PR DESCRIPTION
This might be too niche, in which case feel free to reject it!

This is a quick PR that enables predictions for new points when the metric is precomputed. We assume in this scenario that the provided matrix is in fact distances from the new points to the original points in the training set. This means that the shape of the provided matrix should be (num_new_points, num_training_points).

The matrix can be sparse - in this case, we assume that the nonzero elements of the matrix include the n_neighbors nearest neighbors, or at least the approximate nearest neighbors. We also print a big honking warning so people know what's expected when they try to do this.