### PR TITLE
Add alpha parameter for points and interactive methods in umap.plot

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -259,6 +259,7 @@ def _datashade_points(
     width=800,
     height=800,
     show_legend=True,
+    alpha=255,
 ):
 
     """Use datashader to plot points"""
@@ -286,7 +287,7 @@ def _datashade_points(
         data["label"] = pd.Categorical(labels)
         aggregation = canvas.points(data, "x", "y", agg=ds.count_cat("label"))
         if color_key is None and color_key_cmap is None:
-            result = tf.shade(aggregation, how="eq_hist")
+            result = tf.shade(aggregation, how="eq_hist", alpha=alpha)
         elif color_key is None:
             unique_labels = np.unique(labels)
             num_labels = unique_labels.shape[0]
@@ -297,12 +298,12 @@ def _datashade_points(
                 Patch(facecolor=color_key[i], label=k)
                 for i, k in enumerate(unique_labels)
             ]
-            result = tf.shade(aggregation, color_key=color_key, how="eq_hist")
+            result = tf.shade(aggregation, color_key=color_key, how="eq_hist", alpha=alpha)
         else:
             legend_elements = [
                 Patch(facecolor=color_key[k], label=k) for k in color_key.keys()
             ]
-            result = tf.shade(aggregation, color_key=color_key, how="eq_hist")
+            result = tf.shade(aggregation, color_key=color_key, how="eq_hist", alpha=alpha)
 
     # Color by values
     elif values is not None:
@@ -322,7 +323,7 @@ def _datashade_points(
             )
             aggregation = canvas.points(data, "x", "y", agg=ds.count_cat("val_cat"))
             color_key = _to_hex(plt.get_cmap(cmap)(np.linspace(0, 1, 256)))
-            result = tf.shade(aggregation, color_key=color_key, how="eq_hist")
+            result = tf.shade(aggregation, color_key=color_key, how="eq_hist", alpha=alpha)
         else:
             data["val_cat"] = pd.Categorical(values)
             aggregation = canvas.points(data, "x", "y", agg=ds.count_cat("val_cat"))
@@ -330,12 +331,12 @@ def _datashade_points(
                 plt.get_cmap(cmap)(np.linspace(0, 1, unique_values.shape[0]))
             )
             color_key = dict(zip(unique_values, color_key_cols))
-            result = tf.shade(aggregation, color_key=color_key, how="eq_hist")
+            result = tf.shade(aggregation, color_key=color_key, how="eq_hist", alpha=alpha)
 
     # Color by density (default datashader option)
     else:
         aggregation = canvas.points(data, "x", "y", agg=ds.count())
-        result = tf.shade(aggregation, cmap=plt.get_cmap(cmap))
+        result = tf.shade(aggregation, cmap=plt.get_cmap(cmap), alpha=alpha)
 
     if background is not None:
         result = tf.set_background(result, background)
@@ -361,6 +362,7 @@ def _matplotlib_points(
     width=800,
     height=800,
     show_legend=True,
+    alpha=None,
 ):
     """Use matplotlib to plot points"""
     point_size = 100.0 / np.sqrt(points.shape[0])
@@ -415,7 +417,7 @@ def _matplotlib_points(
             ]
             colors = pd.Series(labels).map(new_color_key)
 
-        ax.scatter(points[:, 0], points[:, 1], s=point_size, c=colors)
+        ax.scatter(points[:, 0], points[:, 1], s=point_size, c=colors, alpha=alpha)
 
     # Color by values
     elif values is not None:
@@ -426,7 +428,7 @@ def _matplotlib_points(
                     values.shape[0], points.shape[0]
                 )
             )
-        ax.scatter(points[:, 0], points[:, 1], s=point_size, c=values, cmap=cmap)
+        ax.scatter(points[:, 0], points[:, 1], s=point_size, c=values, cmap=cmap, alpha=alpha)
 
     # No color (just pick the midpoint of the cmap)
     else:
@@ -476,6 +478,7 @@ def points(
     show_legend=True,
     subset_points=None,
     ax=None,
+    alpha=None,
 ):
     """Plot an embedding as points. Currently this only works
     for 2D embeddings. While there are many optional parameters
@@ -578,6 +581,9 @@ def points(
     ax: matplotlib axis (optional, default None)
         The matplotlib axis to draw the plot to, or if None, which is
         the default, a new axis will be created and returned.
+    
+    alpha: float (optional, default: None)
+        The alpha blending value, between 0 (transparent) and 1 (opaque).
 
     Returns
     -------
@@ -600,6 +606,10 @@ def points(
         raise ValueError(
             "Conflicting options; only one of labels or values should be set"
         )
+
+    if alpha is not None:
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError("Alpha must be between 0 and 1 inclusive")
 
     points = _get_embedding(umap_object)
 
@@ -640,8 +650,15 @@ def points(
             width,
             height,
             show_legend,
+            alpha,
         )
     else:
+        # Datashader uses 0-255 as the range for alpha, with 255 as the default
+        if alpha is not None:
+            alpha = alpha * 255
+        else:
+            alpha = 255
+        
         ax = _datashade_points(
             points,
             ax,
@@ -654,6 +671,7 @@ def points(
             width,
             height,
             show_legend,
+            alpha,
         )
 
     ax.set(xticks=[], yticks=[])


### PR DESCRIPTION
This is an initial PR for https://github.com/lmcinnes/umap/issues/613. I added an optional alpha parameter for the points and interactive methods. I intentionally ignored adding it to the interactive plots for large datasets where holoviews is used. This is due to the fact holoviews/datashader has a min_alpha parameter which is used if alpha < min_alpha. If we want to support this we would also need to set min_alpha appropriately but that might be more trouble than it's worth IMO. I also fixed a bug where the holoviews plots wouldn't display in a Jupyter notebook and were throwing deprecation errors.