### PR TITLE
Update the parametric_reconstruction check for scaled data.

### DIFF
--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -336,7 +336,7 @@ class ParametricUMAP(UMAP):
             if len(self.dims) > 1:
                 X = np.reshape(X, [len(X)] + list(self.dims))
 
-        if (np.max(X) > 1.0) or (np.min(X) < 0.0) and self.parametric_reconstruction:
+        if self.parametric_reconstruction and (np.max(X) > 1.0 or np.min(X) < 0.0):
             warn(
                 "Data should be scaled to the range 0-1 for cross-entropy reconstruction loss."
             )


### PR DESCRIPTION
I'm using `umap==0.5.1`.

When running Parametric UMAP, I received the following warning:

```
Data should be scaled to the range 0-1 for cross-entropy reconstruction loss.
```

I was not using `parametric_reconstruction`, so it seems this warning is not relevant.

The operator precedence rules of Python result in the existing check, `(np.max(X) > 1.0) or (np.min(X) < 0.0) and self.parametric_reconstruction`, being treated as `(np.max(X) > 1.0) or ((np.min(X) < 0.0) and self.parametric_reconstruction)`.

This PR updates the check so that the `np.max` and `np.min` are grouped together (not with the other check), and also updates the code so that `parametric_reconstruction` is checked first, allowing short-circuiting where possible to avoid the `np.max` and `np.min` checks.
