### PR TITLE
Move densmap-related parameter checks out of __init__ to fix sklearn.base.clone error

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1652,8 +1652,8 @@ class UMAP(BaseEstimator):
         self.unique = unique
 
         self.densmap = densmap
-        self.dens_lambda = dens_lambda if densmap else 0.0
-        self.dens_frac = dens_frac if densmap else 0.0
+        self.dens_lambda = dens_lambda
+        self.dens_frac = dens_frac
         self.dens_var_shift = dens_var_shift
         self.output_dens = output_dens
         self.disconnection_distance = disconnection_distance
@@ -1850,8 +1850,8 @@ class UMAP(BaseEstimator):
             raise ValueError("dens_var_shift cannot be negative")
 
         self._densmap_kwds = {
-            "lambda": self.dens_lambda,
-            "frac": self.dens_frac,
+            "lambda": self.dens_lambda if self.densmap else 0.0,
+            "frac": self.dens_frac if self.densmap else 0.0,
             "var_shift": self.dens_var_shift,
             "n_neighbors": self.n_neighbors,
         }


### PR DESCRIPTION
# The problem

Under certain circumstances, `umap.UMAP` can provoke errors when being passed to `sklearn.base.clone()`. I managed to recurrently reproduce this error when adding `UMAP` to a `sklearn.pipeline.Pipeline` object that has a defined `memory` parameter and `sklearn.model_selection.GridSearchCV` has `n_jobs=-1`. When `memory` is defined, `Pipeline` calls `clone()` with the `UMAP` instance as its sole parameter. After cloning the transformer, this function performs a sanity check which uses `is` instead of `==`. This means that the fact that `dens_lambda` and `dens_frac` could change depending on `densmap`, even if their final values are the same as before, could make the comparison fail, thus provoking a `RuntimeError` inside `clone()`.

## Environment
### Runtime
```
python=3.8.4
```

### Relevant modules
```
sklearn=0.24.2
umap=0.5.1
```

## Minimal reproducible example
### Code
```
import tempfile
import umap

from sklearn import datasets, ensemble, model_selection, pipeline, preprocessing

X, y = datasets.load_iris(return_X_y=True)

pipeline_with_umap = pipeline.Pipeline([
    ("normalize", preprocessing.MinMaxScaler()),
    ("project", umap.UMAP()),
    ("classify", ensemble.RandomForestClassifier()),
], memory=tempfile.mkdtemp())

parameter_grid = {
    "project__n_neighbors": (15,),
    "project__random_state": (2021,),
    "project__verbose": (True,),

    "classify__random_state": (2021,)
}

grid_search = model_selection.GridSearchCV(pipeline_with_umap, parameter_grid, scoring="accuracy", cv=10, n_jobs=-1,
                                           return_train_score=True, verbose=3).fit(X, y)
```

### Error
```
  warnings.warn("Estimator fit failed. The score on this train-test"
<REPOSITORY_ROOT>\venv\lib\site-packages\sklearn\model_selection\_validation.py:615: FitFailedWarning: Estimator fit failed. The score on this train-test partition for these parameters will be set to nan. Details: 
Traceback (most recent call last):
  File "<REPOSITORY_ROOT>\venv\lib\site-packages\sklearn\model_selection\_validation.py", line 598, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
  File "<REPOSITORY_ROOT>\venv\lib\site-packages\sklearn\pipeline.py", line 341, in fit
    Xt = self._fit(X, y, **fit_params_steps)
  File "<REPOSITORY_ROOT>\venv\lib\site-packages\sklearn\pipeline.py", line 291, in _fit
    cloned_transformer = clone(transformer)
  File "<REPOSITORY_ROOT>\venv\lib\site-packages\sklearn\utils\validation.py", line 63, in inner_f
    return f(*args, **kwargs)
  File "<REPOSITORY_ROOT>\venv\lib\site-packages\sklearn\base.py", line 85, in clone
    raise RuntimeError('Cannot clone object %s, as the constructor '
RuntimeError: Cannot clone object UMAP(dens_frac=0.0, dens_lambda=0.0, random_state=2021, verbose=True), as the constructor either does not set or modifies parameter dens_frac
```

# The solution

According to [the sklearn documentation on developing a custom estimator](https://scikit-learn.org/stable/developers/develop.html), 

> there should be no logic, not even input validation, and the parameters should not be changed. The corresponding logic should be put where the parameters are used, typically in `fit`.

As such, the solution consists in merely moving the logic from `UMAP.__init__()` elsewhere, such as to `UMAP._validate_parameters()`, as I did. This is what I did in this pull request, which I leave here for your scrutiny.