### PR TITLE
changed default value to switch to python vs tensorflow based iteration

### DIFF
--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -931,9 +931,9 @@ def construct_edge_dataset(
     def gather_index(index):
         return X[index]
 
-    # if X is > 2Gb in size, we need to use a different, slower method for
+    # if X is > 512Mb in size, we need to use a different, slower method for
     #    batching data.
-    gather_indices_in_python = True if X.nbytes * 1e-9 > 2 else False
+    gather_indices_in_python = True if X.nbytes * 1e-9 > 0.5 else False
 
     def gather_X(edge_to, edge_from):
         # gather data from indexes (edges) in either numpy of tf, depending on array size


### PR DESCRIPTION
This just changes the default switch from iterating with a tensorflow backend vs a python backend at a smaller dataset size. 

I was experimenting around a bit and found issues with datasets > 1GB with the tensorflow based iteration. So it seems safer to make the default the python-based iteration/sampling for any dataset bigger than 512MB. The speed gains for the tensorflow-based iteration aren't too big anyway. 