### PR TITLE
Reproducibility for Aligned UMAP

### DIFF
--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -722,6 +722,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
             max_n_edges = e_p_s.shape[0]
 
     embedding_order = np.arange(n_embeddings).astype(np.int32)
+    np.random.seed(rng_state[0])
     np.random.shuffle(embedding_order)
 
     for i in range(max_n_edges):


### PR DESCRIPTION
Propagate a rng state through UMAP alignment using self.transform_seed as the seed.

Resolves Issue: aligned UMAP embeddings are not reproducible using random_state or transform_seed attributes.