### PR TITLE
Fixes #18 and improves #21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn>=0.22
 numba>=0.51.2
 pynndescent>=0.5
 tbb>=2019.0
+tqdm

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -865,9 +865,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
 
                     for offset in range(-window_size, window_size):
                         neighbor_m = m + offset
-                        if (
-                                n_embeddings > neighbor_m >= 0 != offset
-                        ):
+                        if n_embeddings > neighbor_m >= 0 != offset:
                             identified_index = relations[m, offset + window_size, j]
                             if identified_index >= 0:
                                 grad_d -= clip(
@@ -887,9 +885,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
 
                         for offset in range(-window_size, window_size):
                             neighbor_m = m + offset
-                            if (
-                                    n_embeddings > neighbor_m >= 0 != offset
-                            ):
+                            if n_embeddings > neighbor_m >= 0 != offset:
                                 identified_index = relations[m, offset + window_size, k]
                                 if identified_index >= 0:
                                     grad_d -= clip(

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -141,6 +141,8 @@ def _optimize_layout_euclidean_single_epoch(
                 grad_d = clip(grad_coeff * (current[d] - other[d]))
 
                 if densmap_flag:
+                    # FIXME: grad_cor_coeff might be referenced before assignment
+
                     grad_d += clip(2 * grad_cor_coeff * (current[d] - other[d]))
 
                 current[d] += grad_d * alpha
@@ -257,7 +259,7 @@ def optimize_layout_euclidean(
         The number of training epochs to use in optimization.
     n_vertices: int
         The number of vertices (0-simplices) in the dataset.
-    epochs_per_samples: array of shape (n_1_simplices)
+    epochs_per_sample: array of shape (n_1_simplices)
         A float value of the number of epochs per 1-simplex. 1-simplices with
         weaker membership strength will have more epochs between being sampled.
     a: float
@@ -336,6 +338,8 @@ def optimize_layout_euclidean(
         )
 
         if densmap_flag:
+            # FIXME: dens_init_fn might be referenced before assignment
+
             dens_init_fn(
                 head_embedding,
                 tail_embedding,
@@ -347,6 +351,7 @@ def optimize_layout_euclidean(
                 dens_phi_sum,
             )
 
+            # FIXME: dens_var_shift might be referenced before assignment
             dens_re_std = np.sqrt(np.var(dens_re_sum) + dens_var_shift)
             dens_re_mean = np.mean(dens_re_sum)
             dens_re_cov = np.dot(dens_re_sum, dens_R) / (n_vertices - 1)
@@ -513,9 +518,6 @@ def optimize_layout_generic(
 
     tail: array of shape (n_1_simplices)
         The indices of the tails of 1-simplices with non-zero membership.
-
-    weight: array of shape (n_1_simplices)
-        The membership weights of the 1-simplices.
 
     n_epochs: int
         The number of training epochs to use in optimization.
@@ -719,6 +721,10 @@ def optimize_layout_inverse(
 
     weight: array of shape (n_1_simplices)
         The membership weights of the 1-simplices.
+
+    sigmas:
+
+    rhos:
 
     n_epochs: int
         The number of training epochs to use in optimization.

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -2,6 +2,7 @@ import numpy as np
 import numba
 import umap.distances as dist
 from umap.utils import tau_rand_int
+from tqdm.auto import tqdm
 
 
 @numba.njit()
@@ -225,6 +226,7 @@ def optimize_layout_euclidean(
     verbose=False,
     densmap=False,
     densmap_kwds={},
+    tqdm_kwds={},
 ):
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
@@ -273,6 +275,8 @@ def optimize_layout_euclidean(
         Whether to use the density-augmented densMAP objective
     densmap_kwds: dict (optional, default {})
         Auxiliary data for densMAP
+    tqdm_kwds: dict (optional, default {})
+        Keyword arguments for tqdm progress bar.
     Returns
     -------
     embedding: array of shape (n_samples, n_components)
@@ -313,7 +317,10 @@ def optimize_layout_euclidean(
         dens_phi_sum = np.zeros(1, dtype=np.float32)
         dens_re_sum = np.zeros(1, dtype=np.float32)
 
-    for n in range(n_epochs):
+    if 'disable' not in tqdm_kwds:
+        tqdm_kwds['disable'] = not verbose
+
+    for n in tqdm(range(n_epochs), **tqdm_kwds):
 
         densmap_flag = (
             densmap
@@ -373,9 +380,6 @@ def optimize_layout_euclidean(
 
         alpha = initial_alpha * (1.0 - (float(n) / float(n_epochs)))
 
-        if verbose and n % int(n_epochs / 10) == 0:
-            print("\tcompleted ", n, " / ", n_epochs, "epochs")
-
     return head_embedding
 
 
@@ -397,6 +401,7 @@ def optimize_layout_generic(
     output_metric=dist.euclidean,
     output_metric_kwds=(),
     verbose=False,
+    tqdm_kwds={},
 ):
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
@@ -455,6 +460,9 @@ def optimize_layout_generic(
     verbose: bool (optional, default False)
         Whether to report information on the current progress of the algorithm.
 
+    tqdm_kwds: dict (optional, default {})
+        Keyword arguments for tqdm progress bar.
+
     Returns
     -------
     embedding: array of shape (n_samples, n_components)
@@ -469,7 +477,10 @@ def optimize_layout_generic(
     epoch_of_next_negative_sample = epochs_per_negative_sample.copy()
     epoch_of_next_sample = epochs_per_sample.copy()
 
-    for n in range(n_epochs):
+    if 'disable' not in tqdm_kwds:
+        tqdm_kwds['disable'] = not verbose
+
+    for n in tqdm(range(n_epochs), **tqdm_kwds):
         for i in range(epochs_per_sample.shape[0]):
             if epoch_of_next_sample[i] <= n:
                 j = head[i]
@@ -534,9 +545,6 @@ def optimize_layout_generic(
 
         alpha = initial_alpha * (1.0 - (float(n) / float(n_epochs)))
 
-        if verbose and n % int(n_epochs / 10) == 0:
-            print("\tcompleted ", n, " / ", n_epochs, "epochs")
-
     return head_embedding
 
 
@@ -561,6 +569,7 @@ def optimize_layout_inverse(
     output_metric=dist.euclidean,
     output_metric_kwds=(),
     verbose=False,
+    tqdm_kwds={},
 ):
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
@@ -619,6 +628,9 @@ def optimize_layout_inverse(
     verbose: bool (optional, default False)
         Whether to report information on the current progress of the algorithm.
 
+    tqdm_kwds: dict (optional, default {})
+        Keyword arguments for tqdm progress bar.
+
     Returns
     -------
     embedding: array of shape (n_samples, n_components)
@@ -633,7 +645,10 @@ def optimize_layout_inverse(
     epoch_of_next_negative_sample = epochs_per_negative_sample.copy()
     epoch_of_next_sample = epochs_per_sample.copy()
 
-    for n in range(n_epochs):
+    if 'disable' not in tqdm_kwds:
+        tqdm_kwds['disable'] = not verbose
+
+    for n in tqdm(range(n_epochs), **tqdm_kwds):
         for i in range(epochs_per_sample.shape[0]):
             if epoch_of_next_sample[i] <= n:
                 j = head[i]
@@ -685,9 +700,6 @@ def optimize_layout_inverse(
                 )
 
         alpha = initial_alpha * (1.0 - (float(n) / float(n_epochs)))
-
-        if verbose and n % int(n_epochs / 10) == 0:
-            print("\tcompleted ", n, " / ", n_epochs, "epochs")
 
     return head_embedding
 
@@ -873,6 +885,7 @@ def optimize_layout_aligned_euclidean(
     negative_sample_rate=5.0,
     parallel=True,
     verbose=False,
+    tqdm_kwds={},
 ):
     dim = head_embeddings[0].shape[1]
     move_other = head_embeddings[0].shape[0] == tail_embeddings[0].shape[0]
@@ -899,7 +912,10 @@ def optimize_layout_aligned_euclidean(
         parallel=parallel,
     )
 
-    for n in range(n_epochs):
+    if 'disable' not in tqdm_kwds:
+        tqdm_kwds['disable'] = not verbose
+
+    for n in tqdm(range(n_epochs), **tqdm_kwds):
         optimize_fn(
             head_embeddings,
             tail_embeddings,
@@ -923,8 +939,5 @@ def optimize_layout_aligned_euclidean(
         )
 
         alpha = initial_alpha * (1.0 - (float(n) / float(n_epochs)))
-
-        if verbose and n % int(n_epochs / 10) == 0:
-            print("\tcompleted ", n, " / ", n_epochs, "epochs")
 
     return head_embeddings

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -234,8 +234,8 @@ def optimize_layout_euclidean(
     parallel=False,
     verbose=False,
     densmap=False,
-    densmap_kwds={},
-    tqdm_kwds={},
+    densmap_kwds=None,
+    tqdm_kwds=None,
 ):
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
@@ -282,9 +282,9 @@ def optimize_layout_euclidean(
         Whether to report information on the current progress of the algorithm.
     densmap: bool (optional, default False)
         Whether to use the density-augmented densMAP objective
-    densmap_kwds: dict (optional, default {})
+    densmap_kwds: dict (optional, default None)
         Auxiliary data for densMAP
-    tqdm_kwds: dict (optional, default {})
+    tqdm_kwds: dict (optional, default None)
         Keyword arguments for tqdm progress bar.
     Returns
     -------
@@ -303,6 +303,10 @@ def optimize_layout_euclidean(
     optimize_fn = numba.njit(
         _optimize_layout_euclidean_single_epoch, fastmath=True, parallel=parallel
     )
+    if densmap_kwds is None:
+        densmap_kwds = {}
+    if tqdm_kwds is None:
+        tqdm_kwds = {}
 
     if densmap:
         dens_init_fn = numba.njit(
@@ -494,7 +498,7 @@ def optimize_layout_generic(
     output_metric=dist.euclidean,
     output_metric_kwds=(),
     verbose=False,
-    tqdm_kwds={},
+    tqdm_kwds=None,
 ):
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
@@ -550,7 +554,7 @@ def optimize_layout_generic(
     verbose: bool (optional, default False)
         Whether to report information on the current progress of the algorithm.
 
-    tqdm_kwds: dict (optional, default {})
+    tqdm_kwds: dict (optional, default None)
         Keyword arguments for tqdm progress bar.
 
     Returns
@@ -571,6 +575,9 @@ def optimize_layout_generic(
         _optimize_layout_generic_single_epoch,
         fastmath=True,
     )
+
+    if tqdm_kwds is None:
+        tqdm_kwds = {}
 
     if "disable" not in tqdm_kwds:
         tqdm_kwds["disable"] = not verbose
@@ -694,7 +701,7 @@ def optimize_layout_inverse(
     output_metric=dist.euclidean,
     output_metric_kwds=(),
     verbose=False,
-    tqdm_kwds={},
+    tqdm_kwds=None,
 ):
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
@@ -757,7 +764,7 @@ def optimize_layout_inverse(
     verbose: bool (optional, default False)
         Whether to report information on the current progress of the algorithm.
 
-    tqdm_kwds: dict (optional, default {})
+    tqdm_kwds: dict (optional, default None)
         Keyword arguments for tqdm progress bar.
 
     Returns
@@ -778,6 +785,9 @@ def optimize_layout_inverse(
         _optimize_layout_inverse_single_epoch,
         fastmath=True,
     )
+
+    if tqdm_kwds is None:
+        tqdm_kwds = {}
 
     if "disable" not in tqdm_kwds:
         tqdm_kwds["disable"] = not verbose
@@ -979,7 +989,7 @@ def optimize_layout_aligned_euclidean(
     negative_sample_rate=5.0,
     parallel=True,
     verbose=False,
-    tqdm_kwds={},
+    tqdm_kwds=None,
 ):
     dim = head_embeddings[0].shape[1]
     move_other = head_embeddings[0].shape[0] == tail_embeddings[0].shape[0]
@@ -1005,6 +1015,9 @@ def optimize_layout_aligned_euclidean(
         fastmath=True,
         parallel=parallel,
     )
+
+    if tqdm_kwds is None:
+        tqdm_kwds = {}
 
     if "disable" not in tqdm_kwds:
         tqdm_kwds["disable"] = not verbose

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -860,9 +860,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
                     for offset in range(-window_size, window_size):
                         neighbor_m = m + offset
                         if (
-                            neighbor_m >= 0
-                            and neighbor_m < n_embeddings
-                            and offset != 0
+                                n_embeddings > neighbor_m >= 0 != offset
                         ):
                             identified_index = relations[m, offset + window_size, j]
                             if identified_index >= 0:
@@ -884,9 +882,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
                         for offset in range(-window_size, window_size):
                             neighbor_m = m + offset
                             if (
-                                neighbor_m >= 0
-                                and neighbor_m < n_embeddings
-                                and offset != 0
+                                    n_embeddings > neighbor_m >= 0 != offset
                             ):
                                 identified_index = relations[m, offset + window_size, k]
                                 if identified_index >= 0:
@@ -940,11 +936,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
 
                         for offset in range(-window_size, window_size):
                             neighbor_m = m + offset
-                            if (
-                                neighbor_m >= 0
-                                and neighbor_m < n_embeddings
-                                and offset != 0
-                            ):
+                            if n_embeddings > neighbor_m >= 0 != offset:
                                 identified_index = relations[m, offset + window_size, j]
                                 if identified_index >= 0:
                                     grad_d -= clip(

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -183,7 +183,14 @@ def _optimize_layout_euclidean_single_epoch(
 
 
 def _optimize_layout_euclidean_densmap_epoch_init(
-    head_embedding, tail_embedding, head, tail, a, b, re_sum, phi_sum,
+    head_embedding,
+    tail_embedding,
+    head,
+    tail,
+    a,
+    b,
+    re_sum,
+    phi_sum,
 ):
     re_sum.fill(0)
     phi_sum.fill(0)
@@ -317,8 +324,8 @@ def optimize_layout_euclidean(
         dens_phi_sum = np.zeros(1, dtype=np.float32)
         dens_re_sum = np.zeros(1, dtype=np.float32)
 
-    if 'disable' not in tqdm_kwds:
-        tqdm_kwds['disable'] = not verbose
+    if "disable" not in tqdm_kwds:
+        tqdm_kwds["disable"] = not verbose
 
     for n in tqdm(range(n_epochs), **tqdm_kwds):
 
@@ -415,9 +422,7 @@ def _optimize_layout_generic_single_epoch(
             dist_output, grad_dist_output = output_metric(
                 current, other, *output_metric_kwds
             )
-            _, rev_grad_dist_output = output_metric(
-                other, current, *output_metric_kwds
-            )
+            _, rev_grad_dist_output = output_metric(other, current, *output_metric_kwds)
 
             if dist_output > 0.0:
                 w_l = pow((1 + a * pow(dist_output, 2 * b)), -1)
@@ -436,8 +441,7 @@ def _optimize_layout_generic_single_epoch(
             epoch_of_next_sample[i] += epochs_per_sample[i]
 
             n_neg_samples = int(
-                (n - epoch_of_next_negative_sample[i])
-                / epochs_per_negative_sample[i]
+                (n - epoch_of_next_negative_sample[i]) / epochs_per_negative_sample[i]
             )
 
             for p in range(n_neg_samples):
@@ -463,7 +467,7 @@ def _optimize_layout_generic_single_epoch(
                     current[d] += grad_d * alpha
 
             epoch_of_next_negative_sample[i] += (
-                    n_neg_samples * epochs_per_negative_sample[i]
+                n_neg_samples * epochs_per_negative_sample[i]
             )
     return epoch_of_next_sample, epoch_of_next_negative_sample
 
@@ -562,11 +566,12 @@ def optimize_layout_generic(
     epoch_of_next_sample = epochs_per_sample.copy()
 
     optimize_fn = numba.njit(
-        _optimize_layout_generic_single_epoch, fastmath=True,
+        _optimize_layout_generic_single_epoch,
+        fastmath=True,
     )
 
-    if 'disable' not in tqdm_kwds:
-        tqdm_kwds['disable'] = not verbose
+    if "disable" not in tqdm_kwds:
+        tqdm_kwds["disable"] = not verbose
 
     for n in tqdm(range(n_epochs), **tqdm_kwds):
         optimize_fn(
@@ -588,7 +593,7 @@ def optimize_layout_generic(
             n_vertices,
             a,
             b,
-            gamma
+            gamma,
         )
         alpha = initial_alpha * (1.0 - (float(n) / float(n_epochs)))
 
@@ -642,8 +647,7 @@ def _optimize_layout_inverse_single_epoch(
             epoch_of_next_sample[i] += epochs_per_sample[i]
 
             n_neg_samples = int(
-                (n - epoch_of_next_negative_sample[i])
-                / epochs_per_negative_sample[i]
+                (n - epoch_of_next_negative_sample[i]) / epochs_per_negative_sample[i]
             )
 
             for p in range(n_neg_samples):
@@ -664,7 +668,7 @@ def _optimize_layout_inverse_single_epoch(
                     current[d] += grad_d * alpha
 
             epoch_of_next_negative_sample[i] += (
-                    n_neg_samples * epochs_per_negative_sample[i]
+                n_neg_samples * epochs_per_negative_sample[i]
             )
 
 
@@ -765,11 +769,12 @@ def optimize_layout_inverse(
     epoch_of_next_sample = epochs_per_sample.copy()
 
     optimize_fn = numba.njit(
-        _optimize_layout_inverse_single_epoch, fastmath=True,
+        _optimize_layout_inverse_single_epoch,
+        fastmath=True,
     )
 
-    if 'disable' not in tqdm_kwds:
-        tqdm_kwds['disable'] = not verbose
+    if "disable" not in tqdm_kwds:
+        tqdm_kwds["disable"] = not verbose
 
     for n in tqdm(range(n_epochs), **tqdm_kwds):
         optimize_fn(
@@ -1007,8 +1012,8 @@ def optimize_layout_aligned_euclidean(
         parallel=parallel,
     )
 
-    if 'disable' not in tqdm_kwds:
-        tqdm_kwds['disable'] = not verbose
+    if "disable" not in tqdm_kwds:
+        tqdm_kwds["disable"] = not verbose
 
     for n in tqdm(range(n_epochs), **tqdm_kwds):
         optimize_fn(

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -3304,3 +3304,22 @@ class UMAP(BaseEstimator):
         if self.output_dens:
             self.rad_orig_ = aux_data["rad_orig"]
             self.rad_emb_ = aux_data["rad_emb"]
+
+    def __repr__(self):
+        from sklearn.utils._pprint import _EstimatorPrettyPrinter
+        import re
+
+        pp = _EstimatorPrettyPrinter(
+            compact=True,
+            indent=1,
+            indent_at_name=True,
+            n_max_elements_to_show=50,
+        )
+        pp._changed_only = True
+        repr_ = pp.pformat(self)
+        repr_ = re.sub("tqdm_kwds={.*},", "", repr_, flags=re.S)
+        # remove empty lines
+        repr_ = re.sub("\n\s*\n", "\n", repr_, flags=re.S)
+        # remove extra whitespaces after a comma
+        repr_ = re.sub(", +", ", ", repr_)
+        return repr_

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1890,9 +1890,9 @@ class UMAP(BaseEstimator):
         else:
             if isinstance(self.tqdm_kwds, dict) is False:
                 raise ValueError(
-                    "tqdm_kwds must be a dictionary. Please provide valid tqdm parameters as "
-                    "key value pairs. Valid tqdm parameters can be found here: "
-                    "https://github.com/tqdm/tqdm#parameters"
+                    "tqdm_kwds must be a dictionary. Please provide valid tqdm "
+                    "parameters as key value pairs. Valid tqdm parameters can be "
+                    "found here: https://github.com/tqdm/tqdm#parameters"
                 )
         if "desc" not in self.tqdm_kwds:
             self.tqdm_kwds["desc"] = "Epochs completed"
@@ -3319,7 +3319,7 @@ class UMAP(BaseEstimator):
         repr_ = pp.pformat(self)
         repr_ = re.sub("tqdm_kwds={.*},", "", repr_, flags=re.S)
         # remove empty lines
-        repr_ = re.sub("\n\s*\n", "\n", repr_, flags=re.S)
+        repr_ = re.sub("\n *\n", "\n", repr_, flags=re.S)
         # remove extra whitespaces after a comma
         repr_ = re.sub(", +", ", ", repr_)
         return repr_

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2292,7 +2292,7 @@ class UMAP(BaseEstimator):
         random_state = check_random_state(self.random_state)
 
         if self.verbose:
-            print("Construct fuzzy simplicial set")
+            print(ts(), "Construct fuzzy simplicial set")
 
         if self.metric == "precomputed" and self._sparse_data:
             # For sparse precomputed distance matrices, we just argsort the rows to find


### PR DESCRIPTION
Hi @lmcinnes,

This PR improves the aesthetics of the progress log by using `tqdm` progress bar. The progress bar is only shown when `verbose` is set to `True` in the `UMAP` class.

Here is a screenshot of running the digits example data in **Jupyter lab environment**
![umap_tqdm_example_jupyter](https://user-images.githubusercontent.com/10581156/127202630-52a50451-faf5-4c70-99fe-7bc69fbbe61a.JPG)

Here is a screenshot of running the digits example data in **ipython shell**
![umap_tqdm_example_shell](https://user-images.githubusercontent.com/10581156/127202729-205423e7-8efe-45c5-995d-4ec27787f0db.JPG)

The changes have been made to the following functions in `layouts.py` and I have added an extra parameter `tqdm_kwds` to each of them:
- `optimize_layout_euclidean`
- `optimize_layout_generic`
- `optimize_layout_inverse`
- `optimize_layout_aligned_euclidean`

`tqdm_kwds` is dictionary that contains keyword arguments for `tqdm`. Users can use this to override the look and
feel of the progress bar as per their need. Using `tqdm_kwds` it is also possible to disable the progress bar even when `verbose` is set to `True` (could be useful when logging UMAP output).

If you think this is useful then I can continue to work on this and expose the `tqdm_kwds` parameter all the way upto the UMAP class.