### PR TITLE
Fixed bug in umap.plot

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -215,10 +215,10 @@ def _nhood_compare(indices_left, indices_right):
 
 def _get_extent(points):
     """Compute bounds on a space with appropriate padding"""
-    min_x = np.min(points[:, 0])
-    max_x = np.max(points[:, 0])
-    min_y = np.min(points[:, 1])
-    max_y = np.max(points[:, 1])
+    min_x = np.nanmin(points[:, 0])
+    max_x = np.nanmax(points[:, 0])
+    min_y = np.nanmin(points[:, 1])
+    max_y = np.nanmax(points[:, 1])
 
     extent = (
         np.round(min_x - 0.05 * (max_x - min_x)),


### PR DESCRIPTION
Calling umap.plot.connectivity() with a umap object with disconnected vertices caused python to crash. I found that the origin of the error was the _get_extent() function that used np.min and np.max to find the bounds for a plot. When there are disconnected vertices np.min(points)=np.max(points)=np.nan.  

This was fixed by calling np.nanmin() and np.nanmax() instead which ignore nan values.