### PR TITLE
Fix inconsistency between UMAP and ParametricUMAP APIs

### DIFF
--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -230,7 +230,7 @@ class ParametricUMAP(UMAP):
         """
         if self.parametric_embedding:
             return self.encoder.predict(
-                X, batch_size=self.batch_size, verbose=self.verbose
+                np.asanyarray(X), batch_size=self.batch_size, verbose=self.verbose
             )
         else:
             warn(
@@ -253,7 +253,7 @@ class ParametricUMAP(UMAP):
         """
         if self.parametric_reconstruction:
             return self.decoder.predict(
-                X, batch_size=self.batch_size, verbose=self.verbose
+                np.asanyarray(X), batch_size=self.batch_size, verbose=self.verbose
             )
         else:
             return super().inverse_transform(X)


### PR DESCRIPTION
Resolves an issue where `ParametricUMAP.transform()` and `ParametricUMAP.inverse_transform()` raised an error if passed a list of vectors rather than an ndarray when `self.parametric_embedding` and `self.parametric_reconstruction`, respectively. This could have been a source of confusion because it is legal to pass a list to `UMAP.transform()` and `UMAP.inverse_transform()`, as well as all the `.fit()` and `.fit_transform()` methods.

[Colab demonstration of the issue.](https://colab.research.google.com/drive/1q6Pg_Ykbp1WPVCmVgaUIfTueQmOoq4Lk?usp=sharing)