### PR TITLE
Some small changes and formatting

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1568,14 +1568,14 @@ class UMAP(BaseEstimator):
         can also be used when densmap=False to calculate the densities for
         UMAP embeddings.
 
-    disconnection_distance: float (optional, default np.inf or maximal valuefor bounded distances)
+    disconnection_distance: float (optional, default np.inf or maximal value for bounded distances)
         Disconnect any vertices of distance greater than or equal to
         disconnection_distance when approximating the manifold via our k-nn graph.
         This is particularly useful in the case that you have a bounded metric.
         The UMAP assumption that we have a connected manifold can be problematic
         when you have points that are maximally different from all the rest of
-        your data.  The connected manifold assumption will make such points
-        have perfect similarity to a random set of other points.  Too many such
+        your data. The connected manifold assumption will make such points
+        have perfect similarity to a random set of other points. Too many such
         points will artificially connect your space.
     """
 


### PR DESCRIPTION
This PR includes changes that address a few issues I noticed while reading umap_.py:

1.  The weight variable was defined but went unused on several occassions
2.  disconnection_distance docstring wasn't formatted properly
3.  Interpolation and Index were being redefined every loop in the smooth_knn_dist() function

I also ran black formatting on umap_.py
