### PR TITLE
tighten test_umap_trustworthiness_random_init bound

### DIFF
--- a/umap/tests/test_umap_trustworthiness.py
+++ b/umap/tests/test_umap_trustworthiness.py
@@ -49,7 +49,7 @@ def test_umap_trustworthiness_random_init(nn_data):
     ).fit_transform(data)
     trust = trustworthiness(data, embedding, n_neighbors=10)
     assert (
-        trust >= 0.75
+        trust >= 0.8
     ), "Insufficiently trustworthy embedding for" "nn dataset: {}".format(trust)
 
 


### PR DESCRIPTION
Hi,

The test `test_umap_trustworthiness_random_init` in `test_umap_trustworthiness.py` has an assertion bound (`assert (trust >= 0.75)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/162629548-a7afa320-9300-426f-89b1-a6e574b6f01a.png" width="450">
</p>

Here we see that the bound of `0.75` is too loose since the original distribution (in orange) is greater than `0.75`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are above the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/162629563-3a411ce6-6d9b-41b5-a6d1-1be7e27bb1b5.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.75` (red dotted line) has a catch rate of 0.59.

To improve this test, I propose to tighten the bound to `0.68` (the blue dotted line). The new bound has a catch rate of 0.73 (+0.05 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed 100 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
numpy=1.20.3
```

my umap Experiment SHA:
`ec9832cbdb7f106a727e6bbd4c54c78fae30f26f`
