### PR TITLE
feature: add ability to specify tools to interactive charts so richer exploration with images and other content is possible

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1212,6 +1212,7 @@ def interactive(
     labels=None,
     values=None,
     hover_data=None,
+    tools=None,
     theme=None,
     cmap="Blues",
     color_key=None,
@@ -1265,6 +1266,14 @@ def interactive(
         should be a Series of length ``n_samples`` providing a value
         for each data point. Column names will be used for
         identifying information within the tooltip.
+
+    tools: List (optional, default None),
+        Defines the tools to be configured for interactive plots.
+        The list can be mixed type of string and tools objects defined by
+        Bokeh like HoverTool. Default tool list Bokeh uses is
+        ["pan","wheel_zoom","box_zoom","save","reset","help",].
+        When tools are specified, and includes hovertool, automatic tooltip
+        based on hover_data is not created.
 
     theme: string (optional, default None)
         A color theme to use for plotting. A small set of
@@ -1420,15 +1429,19 @@ def interactive(
             hover_data = hover_data[subset_points]
 
     if points.shape[0] <= width * height // 10:
-
+        tooltips = None
         if hover_data is not None:
+            tooltip_needed = True
             tooltip_dict = {}
             for col_name in hover_data:
                 data[col_name] = hover_data[col_name]
                 tooltip_dict[col_name] = "@{" + col_name + "}"
             tooltips = list(tooltip_dict.items())
-        else:
-            tooltips = None
+
+            for _tool in tools:
+                if _tool.__class__.__name__ == "HoverTool":
+                    tooltip_needed = False
+                    break
 
         if alpha is not None:
             data["alpha"] = alpha
@@ -1441,7 +1454,8 @@ def interactive(
         plot = bpl.figure(
             width=width,
             height=height,
-            tooltips=tooltips,
+            tooltips=None if not tooltip_needed else tooltips,
+            tools=tools,
             background_fill_color=background,
         )
         plot.circle(


### PR DESCRIPTION
I ran into a scenario where I needed the interactive plots to show me the images in the tooltip in the thumbnail so I can debug the offending samples. Boken allows this with HoverTool concept that takes in a template of HTML and can render the data as desired. 

In my use case, I have HoverTool defined as the following:

```
hover_tool = HoverTool(tooltips="""
<div>
    <div>
        <img src='@image' style='float: left; margin: 5px 5px 5px 5px'/>
    </div>
    <div>
        <span style='font-size: 16px; color: #224499'>Class:</span>
        <span style='font-size: 18px'>@class</span>
    </div>
    <div>
        <span style='font-size: 16px; color: #224499'>Index:</span>
        <span style='font-size: 18px'>$index</span>
    </div>
    <div>
        <span style='font-size: 16px; color: #224499'>Values:</span>
        <span style='font-size: 18px'>($x, $y)</span>
    </div>
</div>
"""
```

Wherein my `hover_data`  includes base64 encoded images as one of the columns with header `image`, generated using a method similar to the following:


```
    @staticmethod
    def embeddable_image(data):
        img_data = (data[0, 0, ...] * 255).astype(np.uint8)
        image = Image.fromarray(img_data, mode="L").resize((64, 64), Image.BICUBIC)
        buffer = BytesIO()
        image.save(buffer, format="jpeg")
        for_encoding = buffer.getvalue()
        image_blurb = f"data:image/jpg;base64,{base64.b64encode(for_encoding).decode()}"
        return image_blurb
```

Then I apply this method to samples building `hover_data` as follows:

```
df["image"] = list(map(self.embeddable_image, np.vsplit(img_set, img_set.shape[0])))
```

where `df` is my data frame representing `hover_data`. 

So, when I invoke the interactive umap API:

```
        p = umap.plot.interactive(
            mapper,
            labels=r_labels_set,
            hover_data=df,
            point_size=2,
            tools=["pan", "wheel_zoom", "box_zoom", "save", "reset", "help", hover_tool],
            color_key_cmap="Paired",
            background="black",
        )
```

Some example results:

![Screen Shot 2022-04-25 at 10 14 55 pm](https://user-images.githubusercontent.com/25972660/165188659-1e90e497-fd9a-4010-adf8-d8ffbddab5ba.jpg)
![Screen Shot 2022-04-26 at 10 51 13 am](https://user-images.githubusercontent.com/25972660/165197472-9b7a53a1-b924-4f91-8456-b1893ca5d224.jpg)

