### PR TITLE
Fix AlignedUMAP.update

### DIFF
--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -450,7 +450,6 @@ class AlignedUMAP(BaseEstimator):
         X = check_array(X)
 
         self.__dict__ = set_aligned_params(fit_params, self.__dict__, self.n_models_)
-        self.n_models_ += 1
 
         new_mapper = UMAP(
             n_neighbors=get_nth_item_or_val(self.n_neighbors, self.n_models_),
@@ -474,6 +473,7 @@ class AlignedUMAP(BaseEstimator):
             transform_seed=self.transform_seed,
         ).fit(X, y)
 
+        self.n_models_ += 1
         self.mappers_ += [new_mapper]
 
         # TODO: We can likely make this more efficient and not recompute each time

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -165,8 +165,14 @@ PARAM_NAMES = (
 def set_aligned_params(new_params, existing_params, n_models, param_names=PARAM_NAMES):
     for param in param_names:
         if param in new_params:
-            if type(existing_params[param]) in (list, tuple, np.ndarray):
-                existing_params[param] = existing_params[param] + (new_params[param],)
+            if isinstance(existing_params[param], list):
+                existing_params[param].append(new_params[param])
+            elif isinstance(existing_params[param], tuple):
+                existing_params[param] = existing_params[param] + \
+                    (new_params[param],)
+            elif isinstance(existing_params[param], np.ndarray):
+                existing_params[param] = np.append(existing_params[param],
+                                                   new_params[param])
             else:
                 if new_params[param] != existing_params[param]:
                     existing_params[param] = (existing_params[param],) * n_models + (

--- a/umap/tests/test_aligned_umap.py
+++ b/umap/tests/test_aligned_umap.py
@@ -51,3 +51,19 @@ def test_aligned_update(aligned_iris, aligned_iris_relations):
         embd_dmat = pairwise_distances(small_aligned_model.embeddings_[i])
         embd_nn = np.argsort(embd_dmat, axis=1)[:, :10]
         assert nn_accuracy(true_nn, embd_nn) >= 0.45
+
+
+def test_aligned_update_params(aligned_iris, aligned_iris_relations):
+    data, target = aligned_iris
+    n_neighbors = [15, 15, 15, 15, 15]
+    small_aligned_model = AlignedUMAP(n_neighbors=n_neighbors[:3])
+    small_aligned_model.fit(data[:3], relations=aligned_iris_relations[:2])
+    small_aligned_model.update(data[3],
+                               relations=aligned_iris_relations[2],
+                               n_neighbors=n_neighbors[3])
+    for i, slice in enumerate(data[:4]):
+        data_dmat = pairwise_distances(slice)
+        true_nn = np.argsort(data_dmat, axis=1)[:, :10]
+        embd_dmat = pairwise_distances(small_aligned_model.embeddings_[i])
+        embd_nn = np.argsort(embd_dmat, axis=1)[:, :10]
+        assert nn_accuracy(true_nn, embd_nn) >= 0.45

--- a/umap/tests/test_aligned_umap.py
+++ b/umap/tests/test_aligned_umap.py
@@ -1,3 +1,4 @@
+import pytest
 from umap import AlignedUMAP
 from sklearn.metrics import pairwise_distances
 from sklearn.cluster import KMeans
@@ -67,3 +68,15 @@ def test_aligned_update_params(aligned_iris, aligned_iris_relations):
         embd_dmat = pairwise_distances(small_aligned_model.embeddings_[i])
         embd_nn = np.argsort(embd_dmat, axis=1)[:, :10]
         assert nn_accuracy(true_nn, embd_nn) >= 0.45
+
+
+def test_aligned_update_array_error(aligned_iris, aligned_iris_relations):
+    data, target = aligned_iris
+    n_neighbors = [15, 15, 15, 15, 15]
+    small_aligned_model = AlignedUMAP(n_neighbors=n_neighbors[:3])
+    small_aligned_model.fit(data[:3], relations=aligned_iris_relations[:2])
+
+    with pytest.raises(ValueError):
+        small_aligned_model.update(data[3:],
+                                   relations=aligned_iris_relations[2:],
+                                   n_neighbors=n_neighbors[3:])


### PR DESCRIPTION
- Fixes two bugs in `aligned_umap.update`:
    -  if a list of values is specified in `aligned_umap.fit` for parameters like `n_neighbors`, `min_dist`, etc.  and a single value is specified in `aligned_umap.update` for the same parameter, `set_aligned_params` raises error. 
    - when the above bug is fixed, another hidden bug is revealed. `self.n_models_ += 1` update should be done after initializing the mapper in `aligned_umap.update`. Otherwise it returns `IndexError: list index out of range` error.

- Adds a test to reveal above bugs.
- Adds a test to check `ValueError` for the case a list of datasets is provided for `aligned_umap.update`. 