### PR TITLE
fix relations_dictionary problems which prevents from correctly updating aligned_umap

### DIFF
--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -505,9 +505,6 @@ class AlignedUMAP(BaseEstimator):
 
         self.dict_relations_ += [new_dict_relations]
 
-        # TODO: We can likely make this more efficient and not recompute each time
-        new_dict_relations = invert_dict(new_dict_relations)
-
         window_size = fit_params.get("window_size", self.alignment_window_size)
         new_relations = expand_relations(self.dict_relations_, window_size)
 
@@ -537,8 +534,11 @@ class AlignedUMAP(BaseEstimator):
             new_relations,
         )
 
+        # TODO: We can likely make this more efficient and not recompute each time
+        inv_dict_relations = invert_dict(new_dict_relations)
+
         new_embedding = init_from_existing(
-            self.embeddings_[-1], new_mapper.graph_, new_dict_relations
+            self.embeddings_[-1], new_mapper.graph_, inv_dict_relations
         )
 
         self.embeddings_.append(new_embedding)

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -449,9 +449,15 @@ class AlignedUMAP(BaseEstimator):
             )
 
         new_dict_relations = fit_params["relations"]
+        assert isinstance(new_dict_relations, dict)
+
         X = check_array(X)
 
         self.__dict__ = set_aligned_params(fit_params, self.__dict__, self.n_models_)
+
+        # We need n_components to be constant or this won't work
+        if type(self.n_components) in (list, tuple, np.ndarray):
+            raise ValueError("n_components must be a single integer, and cannot vary")
 
         if self.n_epochs is None:
             n_epochs = 200

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -327,6 +327,7 @@ class AlignedUMAP(BaseEstimator):
                 n_epochs=get_nth_item_or_val(self.n_epochs, n),
                 repulsion_strength=get_nth_item_or_val(self.repulsion_strength, n),
                 learning_rate=get_nth_item_or_val(self.learning_rate, n),
+                init=self.init,
                 spread=get_nth_item_or_val(self.spread, n),
                 negative_sample_rate=get_nth_item_or_val(self.negative_sample_rate, n),
                 local_connectivity=get_nth_item_or_val(self.local_connectivity, n),
@@ -473,6 +474,7 @@ class AlignedUMAP(BaseEstimator):
                 self.repulsion_strength, self.n_models_
             ),
             learning_rate=get_nth_item_or_val(self.learning_rate, self.n_models_),
+	    init=self.init,
             spread=get_nth_item_or_val(self.spread, self.n_models_),
             negative_sample_rate=get_nth_item_or_val(
                 self.negative_sample_rate, self.n_models_

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -470,8 +470,21 @@ class AlignedUMAP(BaseEstimator):
             set_op_mix_ratio=get_nth_item_or_val(self.set_op_mix_ratio, self.n_models_),
             unique=get_nth_item_or_val(self.unique, self.n_models_),
             n_components=self.n_components,
+            metric=self.metric,
+            metric_kwds=self.metric_kwds,
+            low_memory=self.low_memory,
             random_state=self.random_state,
+            angular_rp_forest=self.angular_rp_forest,
+            transform_queue_size=self.transform_queue_size,
+            target_n_neighbors=self.target_n_neighbors,
+            target_metric=self.target_metric,
+            target_metric_kwds=self.target_metric_kwds,
+            target_weight=self.target_weight,
             transform_seed=self.transform_seed,
+            force_approximation_algorithm=self.force_approximation_algorithm,
+            verbose=self.verbose,
+            a=self.a,
+            b=self.b,
         ).fit(X, y)
 
         self.n_models_ += 1

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -314,6 +314,12 @@ class AlignedUMAP(BaseEstimator):
 
         self.n_models_ = len(X)
 
+        if self.n_epochs is None:
+            n_epochs = 200
+            self.n_epochs = 200
+        else:
+            n_epochs = self.n_epochs
+
         self.mappers_ = [
             UMAP(
                 n_neighbors=get_nth_item_or_val(self.n_neighbors, n),
@@ -345,11 +351,6 @@ class AlignedUMAP(BaseEstimator):
             ).fit(X[n], y[n])
             for n in range(self.n_models_)
         ]
-
-        if self.n_epochs is None:
-            n_epochs = 200
-        else:
-            n_epochs = self.n_epochs
 
         window_size = fit_params.get("window_size", self.alignment_window_size)
         relations = expand_relations(self.dict_relations_, window_size)
@@ -452,6 +453,12 @@ class AlignedUMAP(BaseEstimator):
 
         self.__dict__ = set_aligned_params(fit_params, self.__dict__, self.n_models_)
 
+        if self.n_epochs is None:
+            n_epochs = 200
+            self.n_epochs = 200
+        else:
+            n_epochs = self.n_epochs
+
         new_mapper = UMAP(
             n_neighbors=get_nth_item_or_val(self.n_neighbors, self.n_models_),
             min_dist=get_nth_item_or_val(self.min_dist, self.n_models_),
@@ -489,11 +496,6 @@ class AlignedUMAP(BaseEstimator):
 
         self.n_models_ += 1
         self.mappers_ += [new_mapper]
-
-        if self.n_epochs is None:
-            n_epochs = 200
-        else:
-            n_epochs = self.n_epochs
 
         self.dict_relations_ += [new_dict_relations]
 

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numba
 from sklearn.base import BaseEstimator
-from sklearn.utils import check_random_state, check_array
+from sklearn.utils import check_array
 
 from umap.sparse import arr_intersect as intersect1d
 from umap.sparse import arr_union as union1d

--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -315,10 +315,9 @@ class AlignedUMAP(BaseEstimator):
         self.n_models_ = len(X)
 
         if self.n_epochs is None:
-            n_epochs = 200
             self.n_epochs = 200
-        else:
-            n_epochs = self.n_epochs
+
+        n_epochs = self.n_epochs
 
         self.mappers_ = [
             UMAP(
@@ -461,10 +460,9 @@ class AlignedUMAP(BaseEstimator):
             raise ValueError("n_components must be a single integer, and cannot vary")
 
         if self.n_epochs is None:
-            n_epochs = 200
             self.n_epochs = 200
-        else:
-            n_epochs = self.n_epochs
+
+        n_epochs = self.n_epochs
 
         new_mapper = UMAP(
             n_neighbors=get_nth_item_or_val(self.n_neighbors, self.n_models_),


### PR DESCRIPTION
Fixes `AlignedUMAP.update` which does not work correctly. 

The relations dictionary is updated with the inverse of the provided relations dictionary. However inverse dictionary should be used only in `init_from_existing` while generating `new_embedding`.

The problem is not revealed when the number of entities over updates are equal and the inverse relation is equal to the relation itself. However when the number of entities increase over updates and the inverse relation is not equal to relation itself, the updates do not create a correct map.

[Here](https://gitlab.inria.fr/hgozukan/cartolabe-data/-/blob/umap_stabilization/examples/aligned_authors_2010_2019.py) is an example notebook to see the how Aligned UMAP works over 10 years data where the number of entities increase over time. If 10 years' data is provided to `AlignedUMAP.fit`at once, it creates correct maps. However if `AlignedUMAP.fit`is used with partial data and the rest is feeded with `AlignedUMAP.update`, updates give incorrect mappings.

I have some other suggestions but I would like to ask your comments before proceeding:

- `fit` function signature has `**fit_params` however it only uses `relations` and `window_size` among these parameters. It gives the wrong impression that we can set fit parameters. I propose to keep `fit` function simple as in `UMAP.fit` and only receive `X`, `y` and `relations` and use `window_size` from `self.alignment_window_size`
- `update` function does not initialize new mapper with the parameters used upon initialization in `fit` function. For example initial mappings might use a `metric` different from default one, but that metric will not be used in the updating mappers. I can change `update` function to initialize mapper using the same parameters in `fit` function.
- are all values in `PARAM_NAMES` relevant for update? For example can we change `metric` for update?
- default `n_epochs` value used in `mapper` and `fit`/`update` are not equal. Does that make any difference. Why is self.n_epochs value not updated with default value? If there is no specific reason, the value could be set in mapper and aligned_umap could use the value from mapper.

If you agree with the proposed changes, I can add them to this PR.

