### PR TITLE
Fixed numerical issue in make_epochs_per_sample

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -916,7 +916,7 @@ def make_epochs_per_sample(weights, n_epochs):
     """
     result = -1.0 * np.ones(weights.shape[0], dtype=np.float64)
     n_samples = n_epochs * (weights / weights.max())
-    result[n_samples > 0] = float(n_epochs) / n_samples[n_samples > 0]
+    result[n_samples > 0] = float(n_epochs) / np.float64(n_samples[n_samples > 0])
     return result
 
 


### PR DESCRIPTION
Fixes issue #635.

The n_samples variable is of type np.float32.  We need to cast it to np.float64 (which matches the type of result) before the division in order to prevent overflows from occurring for extremely small n_samples values.