### PR TITLE
Fix plot not accessible if installed via pip

### DIFF
--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -1,5 +1,6 @@
 from warnings import warn, catch_warnings, simplefilter
 from .umap_ import UMAP
+from . import plot
 
 try:
     with catch_warnings():


### PR DESCRIPTION
I have installed the library via: `pip install umap-learn[plot]`
but when trying:
```
import umap
print(dir(umap))
umap.plot.output_notebook()
```
this error is printed:
```
['AlignedUMAP', 'ParametricUMAP', 'UMAP', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '__warningregistry__', 'aligned_umap', 'catch_warnings', 'distances', 'layouts', 'numba', 'pkg_resources', 'simplefilter', 'sparse', 'spectral', 'umap_', 'utils', 'warn']
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
umap.plot.output_notebook()
AttributeError: module 'umap' has no attribute 'plot'
```

Note that`plot` is not in the list of dirs.

I could fix the import by declaring the `plot` module in `__init__`.