### PR TITLE
Search index is optional for precomputed_knn

### DIFF
--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -219,15 +219,6 @@ def test_umap_inverse_transform_on_iris(iris, iris_model):
         assert np.intersect1d(near_points, highd_near_points[0]).shape[0] >= 3
 
 
-def create_iris_subset_model(iris, iris_selection, seed=42):
-    return UMAP(
-        n_neighbors=10,
-        min_dist=0.01,
-        random_state=seed,
-        force_approximation_algorithm=True,
-    ).fit(iris.data[iris_selection])
-
-
 def test_precomputed_knn_on_iris(iris, iris_selection, iris_subset_model):
     # this to compare two similarity graphs which should be nearly the same
     def rms(a, b):


### PR DESCRIPTION
This is a fix for #848 in the sense that it allows passing only indices and distances to as the `precomputed_knn` parameter (i.e. no pynndescent object required). Things to note:

* You will get a warning that you can't transform new data if you do this.
* If you then try to transform new data via the `transform` method, a `NotImplementedError` will be raised.
* If you have small data and `force_approximation_algorithm=False` you will *not* see the new warning, because the knn will not be used. Setting `force_approximation_algorithm=True` avoids this situation so this new feature works for big and small data.
* docstring for `precomputed_knn` parameter on the `UMAP` constructor has been updated.

Tests successes/warns/failures were the same before and after this addition (there is one failure currently which was failing on upstream-master for me before I added any code). I have added a new test to exercise these various cases.