### PR TITLE
Fix doc build (a bit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ venv
 
 # metadata from pip-installing repo
 umap_learn.egg-info
+
+# docs
+doc/auto_examples
+doc/_build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,23 @@ especially appreciated. To contribute to the documentation please
 [fork the project](https://github.com/lmcinnes/umap/issues#fork-destination-box)
 into your own repository, make changes there, and then submit a pull request.
 
+### Building the Documentation Locally
+
+To build the docs locally, install the documentation tools requirements:
+
+```bash
+sudo pip install -r docs_requirements.txt
+```
+
+Then run:
+
+```bash
+sphinx-build -b html doc doc/_build
+```
+
+This will build the documentation in HTML format. You will be able to find the output
+in the `doc/build` folder.
+
 ## Code
 
 Code contributions are always welcome, from simple bug fixes, to new features. To

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ into your own repository, make changes there, and then submit a pull request.
 To build the docs locally, install the documentation tools requirements:
 
 ```bash
-sudo pip install -r docs_requirements.txt
+pip install -r docs_requirements.txt
 ```
 
 Then run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ sphinx-build -b html doc doc/_build
 ```
 
 This will build the documentation in HTML format. You will be able to find the output
-in the `doc/build` folder.
+in the `doc/_build` folder.
 
 ## Code
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -222,7 +222,7 @@ sphinx_gallery_conf = {
 
 
 def setup(app):
-    app.add_javascript(
+    app.add_js_file(
         "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"
     )
-    app.add_javascript("https://cdn.plot.ly/plotly-latest.min.js")
+    app.add_js_file("https://cdn.plot.ly/plotly-latest.min.js")

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=1.8
 sphinx_gallery
 matplotlib
 pillow


### PR DESCRIPTION
Me again. Yes, I am on a tear today. 

When sphinx 1.8 came out (back in, er, 2018), the api changed `add_javascript` to `add_js_file`. I have updated the `conf.py` to reflect this and set a minimum requirement in `docs_requirements.txt` (although I can't imagine the latter being an actual problem).

Now I get a fair number of errors when I run `sphinx-build` but they are of the fixable type rather than of the oops-sphinx-exploded type.

Also I added a section to the `CONTRIBUTING.MD` about how to build the docs locally. I set the build output to that specified in `doc/Makefile` (which is `_build`) although I couldn't get `make` or `make help` to actually do anything.

Finally, I added the build output to `.gitignore`.