### PR TITLE
PCA initialization option

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1001,6 +1001,7 @@ def simplicial_set_embedding(
         How to initialize the low dimensional embedding. Options are:
             * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
             * 'random': assign initial embedding positions at random.
+            * 'pca': use the first n_components from PCA applied to the input data.
             * A numpy array of initial embedding positions.
 
     random_state: numpy RandomState or equivalent
@@ -1446,6 +1447,7 @@ class UMAP(BaseEstimator):
         How to initialize the low dimensional embedding. Options are:
             * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
             * 'random': assign initial embedding positions at random.
+            * 'pca': use the first n_components from PCA applied to the input data.
             * A numpy array of initial embedding positions.
 
     min_dist: float (optional, default 0.1)


### PR DESCRIPTION
This PR is a bit more than the recent bits of nibbling at low-hanging fruit. It's PCA-based initialization via `init="pca"`, which I recall some users asking for during discussions about spectral initialization troubleshooting.

The implementation is similar to other packages that do this (e.g. [TriMap](https://github.com/eamid/trimap), [PaCMAP](https://github.com/YingfanWang/PaCMAP) and [openTSNE](https://github.com/pavlin-policar/openTSNE)). There is a minor complication compared to those packages because UMAP can work on sparse data. The [sklearn PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) method centers the data and will outright refuse to work with sparse data. Instead for sparse data the [sklearn truncated SVD](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html) is used. For non-sparse data, under the hood, `PCA` will use `TruncatedSVD` if it deems that more efficient.

Some caveats:

1. Given the connection between spectral methods and kernel PCA, and then the connection between kernel PCA with a linear kernel and SVD, it is not clear to me that it makes sense to do PCA on data which doesn't use `metric="euclidean"`. But the code in this PR neither prevents nor warns about it. Should it? As an aside I would love to know if there is an obvious connection between different types of matrix norm and different kernels.
1. Depending on how the input data is scaled, PCA initialization could give a very poor initialization, so the same scaling and noise-addition that applies to the spectral initialization is carried out. I have therefore extracted that code into its own function. I don't know if it now still belongs in the `umap_` module. Also, I called it `noisy_scale_coords` which may not be my finest hour when it comes to naming things. Suggestions welcome.
1. I don't know how to unit test this, so I have yet to add anything to the `tests` directory. Again suggestions welcome. The input coordinates get rescaled twice after PCA initialization so it's not easy to know what the output coordinates should be even with `n_epochs=0`.
    1. I *have* tested this manually with both sparse and dense data and with different metrics, and the results did not look qualitatively worse than the spectral initialization, just the clusters had moved about.
