### PR TITLE
Fix the doc build

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -16,4 +16,5 @@ Useful Functions
 
 .. automodule:: umap.umap_
    :members:
+   :exclude-members: UMAP
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -234,5 +234,5 @@ def setup(app):
 
 
 # This prevents complaints autosummary stub files not being found for each method on
-# the class. See https://stackoverflow.com/questions/65198998/sphinx-warning-autosummary-stub-file-not-found-for-the-methods-of-the-class-c
+# the class. See https://stackoverflow.com/q/65198998
 numpydoc_show_class_members = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.viewcode",
     #    'bokeh.sphinxext.bokeh_plot',
     "sphinx_gallery.gen_gallery",
+    "numpydoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -230,3 +231,8 @@ def setup(app):
         "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"
     )
     app.add_js_file("https://cdn.plot.ly/plotly-latest.min.js")
+
+
+# This prevents complaints autosummary stub files not being found for each method on
+# the class. See https://stackoverflow.com/questions/65198998/sphinx-warning-autosummary-stub-file-not-found-for-the-methods-of-the-class-c
+numpydoc_show_class_members = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,7 +72,7 @@ release = "0.5"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -209,13 +209,17 @@ sphinx_gallery_conf = {
     "gallery_dirs": "auto_examples",
     "plot_gallery": False,  # Turn off running the examples for now
     "reference_url": {
+        # The commented-out URLs are supposed to have search.js files under them.
         "umap": None,
-        "python": "https://docs.python.org/{.major}".format(sys.version_info),
-        "numpy": "https://docs.scipy.org/doc/numpy/",
-        "scipy": "https://docs.scipy.org/doc/scipy/reference",
+        # "python": "https://docs.python.org/{.major}".format(sys.version_info),
+        # Numpy actually DOES have a search.js file but does return valid JSON
+        # (missing double quotes on some property names)
+        # "numpy": "https://docs.scipy.org/doc/numpy/",
+        # scipt ends up with  a 404 for a different URL
+        # "scipy": "https://docs.scipy.org/doc/scipy/reference",
         "matplotlib": "https://matplotlib.org/",
-        "pandas": "https://pandas.pydata.org/pandas-docs/stable/",
-        "sklearn": "http://scikit-learn.org/stable/",
+        # "pandas": "https://pandas.pydata.org/pandas-docs/stable/",
+        # "sklearn": "http://scikit-learn.org/stable/",
         "bokeh": "http://bokeh.pydata.org/en/latest/",
     },
 }

--- a/doc/document_embedding.rst
+++ b/doc/document_embedding.rst
@@ -155,11 +155,11 @@ Let’s look at a couple of sample documents:
     
     
     
-    |>The student of "regional killings" alias Davidian (not the Davidian religios sect) writes:
+    \|>The student of "regional killings" alias Davidian (not the Davidian religios sect) writes:
     
     
-    |>Greater Armenia would stretch from Karabakh, to the Black Sea, to the
-    |>Mediterranean, so if you use the term "Greater Armenia
+    \|>Greater Armenia would stretch from Karabakh, to the Black Sea, to the
+    \|>Mediterranean, so if you use the term "Greater Armenia
     ---------------------------
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -73,6 +73,7 @@ PyPI install, presuming you have numba and sklearn and all its requirements
    aligned_umap_basic_usage
    aligned_umap_politics_demo
    precomputed_k-nn
+   benchmarking
    release_notes
    faq
 

--- a/doc/mutual_nn_umap.rst
+++ b/doc/mutual_nn_umap.rst
@@ -142,4 +142,3 @@ If you use this implementation or reference the results in your work, please cit
     biburl={https://dblp.org/rec/journals/corr/abs-2108-05525.bib},
     bibsource={dblp computer science bibliography, https://dblp.org}
     }
-```

--- a/doc/parametric_umap.rst
+++ b/doc/parametric_umap.rst
@@ -1,5 +1,5 @@
 Parametric (neural network) Embedding
-=============================
+=====================================
 
 .. role:: python(code)
    :language: python
@@ -228,4 +228,4 @@ If you use Parametric UMAP in your work, please cite our paper:
      year={2021},
      publisher={MIT Press One Rogers Street, Cambridge, MA 02142-1209, USA journals-info~…}
    }
-```
+

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -3,3 +3,4 @@ sphinx_gallery
 matplotlib
 pillow
 sphinx_rtd_theme
+numpydoc

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -302,7 +302,7 @@ def nearest_neighbors(
         The distances to the ``n_neighbors`` closest points in the dataset.
 
     rp_forest: list of trees
-        The random projection forest used for searching (if used, None otherwise)
+        The random projection forest used for searching (if used, None otherwise).
     """
     if verbose:
         print(ts(), "Finding Nearest Neighbors")
@@ -384,10 +384,10 @@ def compute_membership_strengths(
         The local connectivity adjustment.
 
     return_dists: bool (optional, default False)
-        Whether to return the pairwise distance associated with each edge
+        Whether to return the pairwise distance associated with each edge.
 
     bipartite: bool (optional, default False)
-        Does the nearest neighbour set represent a bipartite graph?  That is are the
+        Does the nearest neighbour set represent a bipartite graph? That is, are the
         nearest neighbour indices from the same point set as the row indices?
 
     Returns
@@ -480,30 +480,31 @@ def fuzzy_simplicial_set(
         returns a float can be provided. For performance purposes it is
         required that this be a numba jit'd function. Valid string metrics
         include:
-            * euclidean (or l2)
-            * manhattan (or l1)
-            * cityblock
-            * braycurtis
-            * canberra
-            * chebyshev
-            * correlation
-            * cosine
-            * dice
-            * hamming
-            * jaccard
-            * kulsinski
-            * ll_dirichlet
-            * mahalanobis
-            * matching
-            * minkowski
-            * rogerstanimoto
-            * russellrao
-            * seuclidean
-            * sokalmichener
-            * sokalsneath
-            * sqeuclidean
-            * yule
-            * wminkowski
+
+        * euclidean (or l2)
+        * manhattan (or l1)
+        * cityblock
+        * braycurtis
+        * canberra
+        * chebyshev
+        * correlation
+        * cosine
+        * dice
+        * hamming
+        * jaccard
+        * kulsinski
+        * ll_dirichlet
+        * mahalanobis
+        * matching
+        * minkowski
+        * rogerstanimoto
+        * russellrao
+        * seuclidean
+        * sokalmichener
+        * sokalsneath
+        * sqeuclidean
+        * yule
+        * wminkowski
 
         Metrics that take arguments (such as minkowski, mahalanobis etc.)
         can have arguments passed via the metric_kwds dictionary. At this
@@ -988,6 +989,7 @@ def simplicial_set_embedding(
 
     init: string
         How to initialize the low dimensional embedding. Options are:
+
             * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
             * 'random': assign initial embedding positions at random.
             * A numpy array of initial embedding positions.
@@ -1288,7 +1290,7 @@ def init_transform(indices, weights, embedding):
 
 def init_graph_transform(graph, embedding):
     """Given a bipartite graph representing the 1-simplices and strengths between the
-     new points and the original data set along with an embedding of the original points
+    new points and the original data set along with an embedding of the original points
     initialize the positions of new points relative to the strengths (of their neighbors in the source data).
 
     If a point is in our original data set it embeds at the original points coordinates.
@@ -1390,29 +1392,31 @@ class UMAP(BaseEstimator):
         returns a float can be provided. For performance purposes it is
         required that this be a numba jit'd function. Valid string metrics
         include:
-            * euclidean
-            * manhattan
-            * chebyshev
-            * minkowski
-            * canberra
-            * braycurtis
-            * mahalanobis
-            * wminkowski
-            * seuclidean
-            * cosine
-            * correlation
-            * haversine
-            * hamming
-            * jaccard
-            * dice
-            * russelrao
-            * kulsinski
-            * ll_dirichlet
-            * hellinger
-            * rogerstanimoto
-            * sokalmichener
-            * sokalsneath
-            * yule
+
+        * euclidean
+        * manhattan
+        * chebyshev
+        * minkowski
+        * canberra
+        * braycurtis
+        * mahalanobis
+        * wminkowski
+        * seuclidean
+        * cosine
+        * correlation
+        * haversine
+        * hamming
+        * jaccard
+        * dice
+        * russelrao
+        * kulsinski
+        * ll_dirichlet
+        * hellinger
+        * rogerstanimoto
+        * sokalmichener
+        * sokalsneath
+        * yule
+
         Metrics that take arguments (such as minkowski, mahalanobis etc.)
         can have arguments passed via the metric_kwds dictionary. At this
         time care must be taken and dictionary elements must be ordered
@@ -1429,6 +1433,7 @@ class UMAP(BaseEstimator):
 
     init: string (optional, default 'spectral')
         How to initialize the low dimensional embedding. Options are:
+
             * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
             * 'random': assign initial embedding positions at random.
             * A numpy array of initial embedding positions.
@@ -1478,7 +1483,7 @@ class UMAP(BaseEstimator):
         cost, but slightly more accuracy.
 
     transform_queue_size: float (optional, default 4.0)
-        For transform operations (embedding new points using a trained model_
+        For transform operations (embedding new points using a trained model
         this will control how aggressively to search for nearest neighbors.
         Larger values will result in slower performance but more accurate
         nearest neighbor evaluation.


### PR DESCRIPTION
This PR makes `sphinx-build -b html doc doc/_build` complete without warnings or errors. What this required:

* modifying the indentation and other small formatting changes to the docstring and a couple of the `.rst` docs.
* I excluded the UMAP class definition from appearing in the API docs twice (it was appearing once as itself, and once as a module).
* I needed to install `numpydoc` to make the `Parameters`-style docstrings not complain. Possibly `napoleon` was meant based on discussion online, but I don't know enough about this (it did also require adding an extra directive in `conf.py` to stop a complaint about stub files).
* A lot of the sphinx gallery reference URLs to other packages (e.g. Pandas) no longer seem to offer a correct `search.js`, so have been commented out.

I haven't actually checked the generated documents (the penguins dataset example definitely needs some URLs fixed) but this is a good start I think.