### PR TITLE
new spectral initialization option: a truncated SVD-warmed lobpcg 

### DIFF
--- a/umap/spectral.py
+++ b/umap/spectral.py
@@ -133,7 +133,7 @@ def component_layout(
                     component_centroids, metric=metric, **metric_kwds
                 )
 
-    affinity_matrix = np.exp(-(distance_matrix ** 2))
+    affinity_matrix = np.exp(-(distance_matrix**2))
 
     component_embedding = SpectralEmbedding(
         n_components=dim, affinity="precomputed", random_state=random_state

--- a/umap/spectral.py
+++ b/umap/spectral.py
@@ -1,9 +1,12 @@
+import warnings
+
 from warnings import warn
 
 import numpy as np
 
 import scipy.sparse
 import scipy.sparse.csgraph
+import sklearn.decomposition
 
 from sklearn.manifold import SpectralEmbedding
 from sklearn.metrics import pairwise_distances
@@ -352,3 +355,106 @@ def spectral_layout(data, graph, dim, random_state, metric="euclidean", metric_k
             "Falling back to random initialisation!"
         )
         return random_state.uniform(low=-10.0, high=10.0, size=(graph.shape[0], dim))
+
+
+def tswspectral_layout(
+    data, graph, dim, random_state, metric="euclidean", metric_kwds={}
+):
+    """Given a graph compute the spectral embedding of the graph. This is
+    simply the eigenvectors of the laplacian of the graph. Here we use the
+    normalized laplacian and a truncated SVD-based guess of the
+    eigenvectors to "warm" up the lobpcg eigensolver. This function should
+    give results of similar accuracy to the spectral_layout function, but
+    may converge more quickly for graph Laplacians that cause
+    spectral_layout to take an excessive amount of time to complete.
+
+    Parameters
+    ----------
+    data: array of shape (n_samples, n_features)
+        The source data
+
+    graph: sparse matrix
+        The (weighted) adjacency matrix of the graph as a sparse matrix.
+
+    dim: int
+        The dimension of the space into which to embed.
+
+    random_state: numpy RandomState or equivalent
+        A state capable being used as a numpy random state.
+
+    metric: string or callable (optional, default 'euclidean')
+        The metric used to measure distances among the source data points.
+        Used only if the multiple connected components are found in the
+        graph.
+
+    metric_kwds: dict (optional, default {})
+        Keyword arguments to be passed to the metric function.
+        If metric is 'precomputed', 'linkage' keyword can be used to specify
+        'average', 'complete', or 'single' linkage. Default is 'average'.
+        Used only if the multiple connected components are found in the
+        graph.
+
+    Returns
+    -------
+    embedding: array of shape (n_vertices, dim)
+        The spectral embedding of the graph.
+    """
+    n_samples = graph.shape[0]
+    n_components, labels = scipy.sparse.csgraph.connected_components(graph)
+
+    if n_components > 1:
+        return multi_component_layout(
+            data,
+            graph,
+            n_components,
+            labels,
+            dim,
+            random_state,
+            metric=metric,
+            metric_kwds=metric_kwds,
+        )
+
+    diag_data = np.asarray(graph.sum(axis=0))
+    D = scipy.sparse.spdiags(1.0 / np.sqrt(diag_data), 0, n_samples, n_samples)
+    # L is a shifted version of what we will pass to the eigensolver (I - L)
+    # The eigenvectors of I - L coincide with the first few singular vectors
+    # of L so we can carry out truncated SVD on L to get a guess to pass to lobpcg
+    L = D * graph * D
+
+    k = dim + 1
+    tsvd = sklearn.decomposition.TruncatedSVD(
+        n_components=k, random_state=random_state, algorithm="arpack", tol=1e-2
+    )
+    guess = tsvd.fit_transform(L)
+
+    # for a normalized Laplacian, the first eigenvector is always sqrt(D) so replace
+    # the tsvd guess with the exact value. Scaling it to length one seems to help.
+    guess[:, 0] = np.sqrt(diag_data[0] / np.linalg.norm(diag_data[0]))
+
+    I = scipy.sparse.identity(n_samples, dtype=np.float64)
+
+    # lobpcg emits a UserWarning if convergence was not reached within `maxiter`
+    # so we will just have to catch that instead of an Error
+    # This will also trigger when lobpcg decides the problem size is too small
+    # for it to deal with but there is little chance that this would happen
+    # in most real use cases
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            eigenvalues, eigenvectors = scipy.sparse.linalg.lobpcg(
+                I - L,
+                guess,
+                largest=False,
+                tol=1e-4,
+                maxiter=graph.shape[0] * 5,
+            )
+        except UserWarning:
+            warn(
+                "WARNING: spectral initialisation failed! The eigenvector solver\n"
+                "failed. This is likely due to too small an eigengap. Consider\n"
+                "adding some noise or jitter to your data.\n\n"
+                "Falling back to random initialisation!"
+            )
+            return random_state.uniform(low=-10.0, high=10.0, size=(n_samples, dim))
+    order = np.argsort(eigenvalues)[1:k]
+    return eigenvectors[:, order]

--- a/umap/tests/test_spectral.py
+++ b/umap/tests/test_spectral.py
@@ -1,0 +1,22 @@
+from umap.spectral import spectral_layout, tswspectral_layout
+
+import numpy as np
+
+
+def test_tsw_spectral_init(iris):
+    # create an arbitrary (dense) random affinity matrix
+    seed = 42
+    rng = np.random.default_rng(seed=seed)
+    # matrix must be of sufficient size of lobpcg will refuse to work on it
+    n = 20
+    graph = rng.standard_normal(n * n).reshape((n, n)) ** 2
+    graph = graph.T * graph
+
+    spec = spectral_layout(None, graph, 2, random_state=seed)
+    tsw_spec = tswspectral_layout(None, graph, 2, random_state=seed)
+
+    # make sure the two methods produce matrices that are close in values
+    rmsd = np.sqrt(np.mean(np.sum((np.abs(spec) - np.abs(tsw_spec)) ** 2, axis=1)))
+    assert (
+        rmsd < 1e-6
+    ), "tsvd-warmed spectral init insufficiently close to standard spectral init"

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1795,18 +1795,26 @@ class UMAP(BaseEstimator):
         if self.n_components < 1:
             raise ValueError("n_components must be greater than 0")
         self.n_epochs_list = None
-        if isinstance(self.n_epochs, list) or isinstance(self.n_epochs, tuple) or \
-                isinstance(self.n_epochs, np.ndarray):
-            if not issubclass(np.array(self.n_epochs).dtype.type, np.integer) or \
-                    not np.all(np.array(self.n_epochs) >= 0):
-                raise ValueError("n_epochs must be a nonnegative integer "
-                                 "or a list of nonnegative integers")
+        if (
+            isinstance(self.n_epochs, list)
+            or isinstance(self.n_epochs, tuple)
+            or isinstance(self.n_epochs, np.ndarray)
+        ):
+            if not issubclass(
+                np.array(self.n_epochs).dtype.type, np.integer
+            ) or not np.all(np.array(self.n_epochs) >= 0):
+                raise ValueError(
+                    "n_epochs must be a nonnegative integer "
+                    "or a list of nonnegative integers"
+                )
             self.n_epochs_list = list(self.n_epochs)
         elif self.n_epochs is not None and (
-                self.n_epochs < 0 or not isinstance(self.n_epochs, int)
+            self.n_epochs < 0 or not isinstance(self.n_epochs, int)
         ):
-            raise ValueError("n_epochs must be a nonnegative integer "
-                             "or a list of nonnegative integers")
+            raise ValueError(
+                "n_epochs must be a nonnegative integer "
+                "or a list of nonnegative integers"
+            )
         if self.metric_kwds is None:
             self._metric_kwds = {}
         else:
@@ -2765,7 +2773,9 @@ class UMAP(BaseEstimator):
             print(ts(), "Construct embedding")
 
         if self.transform_mode == "embedding":
-            epochs = self.n_epochs_list if self.n_epochs_list is not None else self.n_epochs
+            epochs = (
+                self.n_epochs_list if self.n_epochs_list is not None else self.n_epochs
+            )
             self.embedding_, aux_data = self._fit_embed_data(
                 self._raw_data[index],
                 epochs,
@@ -2775,11 +2785,15 @@ class UMAP(BaseEstimator):
 
             if self.n_epochs_list is not None:
                 if "embedding_list" not in aux_data:
-                    raise KeyError("No list of embedding were found in 'aux_data'. "
-                                   "It is likely the layout optimization function "
-                                   "doesn't support the list of int for 'n_epochs'.")
+                    raise KeyError(
+                        "No list of embedding were found in 'aux_data'. "
+                        "It is likely the layout optimization function "
+                        "doesn't support the list of int for 'n_epochs'."
+                    )
                 else:
-                    self.embedding_list_ = [e[inverse] for e in aux_data["embedding_list"]]
+                    self.embedding_list_ = [
+                        e[inverse] for e in aux_data["embedding_list"]
+                    ]
 
             # Assign any points that are fully disconnected from our manifold(s) to have embedding
             # coordinates of np.nan.  These will be filtered by our plotting functions automatically.

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1477,7 +1477,7 @@ class UMAP(BaseEstimator):
             * 'random': assign initial embedding positions at random.
             * 'pca': use the first n_components from PCA applied to the
             input data.
-            * 'twspectral': use a spectral embedding of the fuzzy
+            * 'tswspectral': use a spectral embedding of the fuzzy
             1-skeleton, using a truncated singular value decomposition to
             "warm" up the eigensolver. This is intended as an alternative
             to the 'spectral' method, if that takes an  excessively long


### PR DESCRIPTION
As mentioned in #918 I have noticed that some datasets cause the spectral initialization step to take a lot longer than usual. These include several used in the [Stochastic Cluster Embedding paper](https://arxiv.org/abs/2108.08003), and which are available for download from the [sce github repo](https://github.com/rozyangno/sce). In particular [tomoradar](https://github.com/rozyangno/sce#tomoradar-data-set), [flow cytometry](https://github.com/rozyangno/sce#flow-cytometry-data-set) and [shuttle](https://github.com/rozyangno/sce#shuttle-data-set) take longer than they should (shuttle isn't so bad in absolute terms, but the other two take several minutes). I have also noticed that the [mammoth](https://pair-code.github.io/understanding-umap/) dataset in the form used by Understanding UMAP takes a surprisingly long time.

As a solution I propose that [`lobpcg`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.lobpcg.html), which is only used for very large problems in the `spectral_layout` function, can work quite well as a general alternative to [`eigsh`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html) *if* you provide a decent initial guess for the eigenvectors. And it turns out [truncated SVD](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html) can provide that guess: you can shift the graph laplacian cheaply and the singular vectors will correspond to the unshifted laplacian's eigenvectors. The settings `algorithm="arpack", tol=1e-2` work well.

With these changes (and with `n_neighbors=50` to avoid complications from more than one connected component in the input graph) I was able to get `cytometry`'s initialization to drop from 20 minutes to 2 minutes, `tomoradar` from 4 minutes to 20 seconds, `shuttle` from 54 seconds to 8 seconds, and `mammoth` from 50 seconds to 8 seconds, which seems like a worthwhile time saving. The layouts that result seem to be at least as reasonable as those with `spectral_layout`.

I also looked at datasets that were not having problems with `spectral_layout` and while these do not run consistently faster with the new method, none of them suddenly started taking anomalously long either. UMAP results also looked in line with what I expect. That said, this is not supposed to *replace* the existing `spectral_layout`, but to provide an alternative for difficult cases. I have also only looked at `n_components=2`, but I assume that is the most common use case with UMAP.

## The implementation

* I have added this as a separate function `tsw_spectral_layout`. TSW as in "Truncated Svd Warmed", because it provides a "warm" start to `lobpcg`. Horrid name I know. I am open to suggestions for something better.
* You can get it by setting `init="tswspectral"`.
* As it is a bit experimental it does not replace or insert itself into any other part of the initialization. If multiple components are detected in the input graph, it bails out to `multi_component_layout` just like `spectral_layout`.
* I envisage it being used as an initialization of last resort if the standard default spectral layout is taking way too long and seems to have complete ground to a halt.
* If convergence fails then you get a warning rather than an error being raised, so we look for that. That means other warnings get caught in the dragnet, but whatever calls the warning, it's rarely good news for the result so falling back to random initialization in any case is probably justifiable.
* I have added a test that the result of `tsw_spectral_layout` and `spectral_layout` are close.
* for some reason, when I ran `black` other bits of the modules got reformatted. Not sure how they got away for so long. I've kept those changes in this PR.

## Some obvious questions

This bit is only worth reading if you got this far and thought "this seems a bit ornate, surely there's an easier way to make `spectral_layout` work better?!". That may be the case, imaginary interlocutor, but I was unable to find it:

* can the `eigsh` routine be improved? `eigsh` doesn't let you provide a guess for all the eigenvectors, just the first one (`v0`). Now as it happens there may be some confusion around the eigenvectors of the graph laplacian in the code because currently we pass a vector of ones as the guess. However, while that is the smallest eigenvector associated with the un-normalized graph Laplacian, the smallest eigenvector for the symmetrized normalized graph laplacian is actually $D^{1/2}$ which we already calculate (just take the square root of `diag_data[0]`). Infuriatingly while this does often help, it doesn't consistently do better than guessing all ones for `v0`. Oh well.
* `eigsh` uses arpack under the hood just like truncated SVD, why not use that? I was not able to get `eigsh` to produce decent cheap results as easily as truncated SVD.
* or what about using the `shift` features of either `eigsh` or `lobpcg` and use the shifted laplacian with them instead of truncated SVD? Whenever I tried this it actually made things a lot slower.
* can we improve the guess to `lobpcg` without getting truncated SVD involved, by for example passing $D^{1/2}$ as the first column? Unlike `eigsh`, that does actually help and reduced the number of datasets where convergence failed, but there were still some failures, while convergence was always seen with the truncated SVD guess.
* is there a cheap diagonal preconditioner available for use with `lobpcg`? My understanding is that the inverse of a graph laplacian is related to the commute distance between items in the dataset but I couldn't find a cheap and easy way to approximate that. 
* is the truncated SVD routine on its own good enough to provide the eigenvectors directly? In my tests, it is not competitive with `eigsh` and `lobpcg` at the tolerances we require.
* instead of the `arpack` algorithm for truncated SVD, what about the `randomized` version? That algorithm is fast, but seems to give a good low-rank approximation, but not necessarily a highly accurate SVD, which `lobpcg` really needs (at least so it would seem for UMAP-created graph laplacians).
