### PR TITLE
ignore force approximation with precomputed knn

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1977,13 +1977,8 @@ class UMAP(BaseEstimator):
                     "precomputed_knn[0] and precomputed_knn[1]"
                     " must be numpy arrays of the same size."
                 )
-            # #848: warn but proceed if no search index is present...
-            # ...but actually don't warn if the data is small and
-            # force_approximation_algorithm=False because this knn data will get ignored
-            # later anyway
-            if not isinstance(self.knn_search_index, NNDescent) and (
-                self.knn_dists.shape[0] >= 4096 or self.force_approximation_algorithm
-            ):
+            # #848: warn but proceed if no search index is present
+            if not isinstance(self.knn_search_index, NNDescent):
                 warn(
                     "precomputed_knn[2] (knn_search_index) "
                     "is not an NNDescent object: transforming new data with transform "
@@ -2011,11 +2006,9 @@ class UMAP(BaseEstimator):
                 self.knn_dists.shape[0] < 4096
                 and not self.force_approximation_algorithm
             ):
-                warn(
-                    "precomputed_knn is meant for large datasets. Since your"
-                    " data is small, precomputed_knn will be ignored and the"
-                    " k-nn will be computed normally."
-                )
+                # force_approximation_algorithm is irrelevant for pre-computed knn
+                # always set it to True which keeps downstream code paths working
+                self.force_approximation_algorithm = True
             elif self.knn_dists.shape[1] > self.n_neighbors:
                 # if k for precomputed_knn larger than n_neighbors we simply prune it
                 self.knn_indices = self.knn_indices[:, : self.n_neighbors]


### PR DESCRIPTION
In #909 I added the ability to provide a precomputed knn without also having to fake out UMAP with a dummy NNDescent class. But you still had to explicitly set `force_approximation_algorithm=True` in the small data case, which is odd and confusing. In #848 @lmcinnes commented that this should probably be an allowed scenario.

I am revisiting the issue due to #926, where a pre-computed knn came up again and I realized that even when #909 becomes part of an official UMAP release, it remains awkward to have to remember to  set `force_approximation_algorithm=True`. 

This PR now forces `force_approximation_algorithm=True` when the data is small and precomputed knn is provided, ignoring what the user provides (note that this parameter was only added to help with unit testing and is not documented). A simple example of creating a distance matrix and then using it with UMAP now looks like:

```python
import matplotlib.pyplot as plt
import sklearn.metrics
import umap.umap_ as umap
from sklearn.datasets import load_iris
from umap.umap_ import nearest_neighbors

iris = load_iris()
iris_dm = sklearn.metrics.pairwise_distances(iris.data)

knn_correlation = nearest_neighbors(
    iris_dm,
    n_neighbors=15,
    metric="precomputed",
    metric_kwds=None,
    angular=False,
    random_state=None,
)

knn_embeddings = umap.UMAP(
    n_neighbors=15,
    min_dist=0.1,
    precomputed_knn=knn_correlation,
).fit_transform(iris.data)

plt.scatter(knn_embeddings[:, 0], knn_embeddings[:, 1], c=iris.target, alpha=0.5)
```

You will still get a warning that the umap transformer cannot be used for transforming new data (which is correct), but there is no longer the need to set any unexpected parameters, nor is there the risk that your knn will be ignored if you do forget to set an undocumented parameter, so IMO this represents a substantial improvement over the same example in #926.

The only other code changes are for the tests which I originally added for #909 which characterized when warnings would and wouldn't occur. This change simplifies that logic substantially so the number of tests has been reduced.