### PR TITLE
Aligned umap issues

### DIFF
--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -176,7 +176,7 @@ def _optimize_layout_euclidean_single_epoch(
                     if grad_coeff > 0.0:
                         grad_d = clip(grad_coeff * (current[d] - other[d]))
                     else:
-                        grad_d = 4.0
+                        grad_d = 0
                     current[d] += grad_d * alpha
 
             epoch_of_next_negative_sample[i] += (
@@ -972,7 +972,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
                         if grad_coeff > 0.0:
                             grad_d = clip(grad_coeff * (current[d] - other[d]))
                         else:
-                            grad_d = 4.0
+                            grad_d = 0.0
 
                         for offset in range(-window_size, window_size):
                             neighbor_m = m + offset

--- a/umap/layouts.py
+++ b/umap/layouts.py
@@ -926,7 +926,7 @@ def _optimize_layout_aligned_euclidean_single_epoch(
                             if n_embeddings > neighbor_m >= 0 != offset:
                                 identified_index = relations[m, offset + window_size, k]
                                 if identified_index >= 0:
-                                    grad_d -= clip(
+                                    other_grad_d -= clip(
                                         (lambda_ * np.exp(-(np.abs(offset) - 1)))
                                         * regularisation_weights[
                                             m, offset + window_size, k


### PR DESCRIPTION
This pull request fixes issues in the AlignedUMAP.

Specifically, changing the gradient from max to zero for duplicate points prevents clusters containing duplicate points from being spread along a line where all coordinates are equal.

The second commit fixes an incorrect variable in the move_other part of the AlignedUMAP optimization.