### PR TITLE
Allow UMAP to accept data with nan or inf values

### DIFF
--- a/.idea/umap-nan.iml
+++ b/.idea/umap-nan.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (umap-nan)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="NUMPY" />
+    <option name="myDocStringFormat" value="NumPy" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/umap/distances.py
+++ b/umap/distances.py
@@ -1283,7 +1283,7 @@ def chunked_parallel_special_metric(X, Y=None, metric=hellinger, chunk_size=16):
     return result
 
 
-def pairwise_special_metric(X, Y=None, metric="hellinger", kwds=None):
+def pairwise_special_metric(X, Y=None, metric="hellinger", kwds=None, force_all_finite=True):
     if callable(metric):
         if kwds is not None:
             kwd_vals = tuple(kwds.values())
@@ -1294,7 +1294,7 @@ def pairwise_special_metric(X, Y=None, metric="hellinger", kwds=None):
         def _partial_metric(_X, _Y=None):
             return metric(_X, _Y, *kwd_vals)
 
-        return pairwise_distances(X, Y, metric=_partial_metric)
+        return pairwise_distances(X, Y, metric=_partial_metric, force_all_finite=force_all_finite)
     else:
         special_metric_func = named_distances[metric]
     return parallel_special_metric(X, Y, metric=special_metric_func)

--- a/umap/tests/test_data_input.py
+++ b/umap/tests/test_data_input.py
@@ -1,23 +1,17 @@
 import numpy as np
 import pytest as pytest
-
-# Check Data Input
-# -----------------------
 from numba import njit
-
 from umap import UMAP
 
 
 @pytest.fixture(scope="session")
 def all_finite_data():
-    d = np.arange(100.0).reshape(25, 4)
-    return d
+    return np.arange(100.0).reshape(25, 4)
 
 
 @pytest.fixture(scope="session")
 def inverse_data():
-    d = np.arange(50).reshape(25, 2)
-    return d
+    return np.arange(50).reshape(25, 2)
 
 
 @njit
@@ -28,28 +22,64 @@ def nan_dist(a: np.ndarray, b: np.ndarray):
 
 
 def test_check_input_data(all_finite_data, inverse_data):
+    """
+    Data input to UMAP gets checked for liability.
+    This tests checks the if data input is dismissed/accepted
+    according to the "force_all_finite" keyword as used by
+    sklearn.
+
+    Parameters
+    ----------
+    all_finite_data
+    inverse_data
+    -------
+
+    """
     inf_data = all_finite_data.copy()
     inf_data[0] = np.inf
-
     nan_data = all_finite_data.copy()
     nan_data[0] = np.nan
+    inf_nan_data = all_finite_data.copy()
+    inf_nan_data[0] = np.nan
+    inf_nan_data[1] = np.inf
 
-    u = UMAP(metric=nan_dist)
+    # wrapper to call each data handling function of UMAP in a convenient way
+    def call_umap_functions(data, force_all_finite):
+        u = UMAP(metric=nan_dist)
+        if force_all_finite is None:
+            u.fit_transform(data)
+            u.fit(data)
+            u.transform(data)
+            u.update(data)
+            u.inverse_transform(inverse_data)
+        else:
+            u.fit_transform(data, force_all_finite=force_all_finite)
+            u.fit(data, force_all_finite=force_all_finite)
+            u.transform(data, force_all_finite=force_all_finite)
+            u.update(data, force_all_finite=force_all_finite)
+            u.inverse_transform(inverse_data)
 
-    u.fit_transform(all_finite_data)
-    u.fit(all_finite_data)
-    u.transform(all_finite_data)
-    u.update(all_finite_data)
-    u.inverse_transform(inverse_data)
+    # Check whether correct data input is accepted
+    call_umap_functions(all_finite_data, None)
+    call_umap_functions(all_finite_data, True)
 
-    u.fit_transform(nan_data, force_all_finite='allow-nan')
-    u.fit(nan_data, force_all_finite='allow-nan')
-    u.transform(nan_data, force_all_finite='allow-nan')
-    u.update(nan_data, force_all_finite='allow-nan')
-    u.inverse_transform(inverse_data)
+    call_umap_functions(nan_data, 'allow-nan')
+    call_umap_functions(all_finite_data, 'allow-nan')
 
-    u.fit_transform(inf_data, force_all_finite=False)
-    u.fit(inf_data, force_all_finite=False)
-    u.transform(inf_data, force_all_finite=False)
-    u.update(inf_data, force_all_finite=False)
-    u.inverse_transform(inverse_data)
+    call_umap_functions(inf_data, False)
+    call_umap_functions(inf_nan_data, False)
+    call_umap_functions(nan_data, False)
+    call_umap_functions(all_finite_data, False)
+
+    # Check whether illegal data raises a ValueError
+    with pytest.raises(ValueError):
+        call_umap_functions(nan_data, None)
+        call_umap_functions(inf_data, None)
+        call_umap_functions(inf_nan_data, None)
+
+        call_umap_functions(nan_data, True)
+        call_umap_functions(inf_data, True)
+        call_umap_functions(inf_nan_data, True)
+
+        call_umap_functions(inf_data, 'allow-nan')
+        call_umap_functions(inf_nan_data, 'allow-nan')

--- a/umap/tests/test_data_input.py
+++ b/umap/tests/test_data_input.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest as pytest
+
+# Check Data Input
+# -----------------------
+from numba import njit
+
+from umap import UMAP
+
+
+@pytest.fixture(scope="session")
+def all_finite_data():
+    d = np.arange(100.0).reshape(25, 4)
+    return d
+
+
+@pytest.fixture(scope="session")
+def inverse_data():
+    d = np.arange(50).reshape(25, 2)
+    return d
+
+
+@njit
+def nan_dist(a: np.ndarray, b: np.ndarray):
+    a[0] = np.nan
+    a[1] = np.inf
+    return 0, a
+
+
+def test_check_input_data(all_finite_data, inverse_data):
+    inf_data = all_finite_data.copy()
+    inf_data[0] = np.inf
+
+    nan_data = all_finite_data.copy()
+    nan_data[0] = np.nan
+
+    u = UMAP(metric=nan_dist)
+
+    u.fit_transform(all_finite_data)
+    u.fit(all_finite_data)
+    u.transform(all_finite_data)
+    u.update(all_finite_data)
+    u.inverse_transform(inverse_data)
+
+    u.fit_transform(nan_data, force_all_finite='allow-nan')
+    u.fit(nan_data, force_all_finite='allow-nan')
+    u.transform(nan_data, force_all_finite='allow-nan')
+    u.update(nan_data, force_all_finite='allow-nan')
+    u.inverse_transform(inverse_data)
+
+    u.fit_transform(inf_data, force_all_finite=False)
+    u.fit(inf_data, force_all_finite=False)
+    u.transform(inf_data, force_all_finite=False)
+    u.update(inf_data, force_all_finite=False)
+    u.inverse_transform(inverse_data)


### PR DESCRIPTION
Based on our [discussion](https://github.com/lmcinnes/umap/discussions/953) about nan-values and custom metrics, I finally had time to (hopefully) properly address the issue.

I exposed the 'force_all_finite' parameters of sklearn's check array functions to UMAP's data handling functions. The default is "force_all_finite=True" which means that this change shouldn't break anything. I also included a test case to test data inputs in respect to accepting/dismising nan's or inf's.

However, I DON'T check if the selected metric is fine with nan or inf values!
