### PR TITLE
docs: minor typos fix

### DIFF
--- a/doc/densmap_demo.rst
+++ b/doc/densmap_demo.rst
@@ -57,7 +57,7 @@ to compare to. We’ll start with MNIST digits.
 
 Now let’s try running DensMAP instead. In practice this is as easy as
 adding the parameter ``densmap=True`` to the UMAP constructor – this
-will cause UMAP use DensMAP regularization with the default DensMAP
+will cause UMAP to use DensMAP regularization with the default DensMAP
 parameters.
 
 .. code:: python3

--- a/doc/parametric_umap.rst
+++ b/doc/parametric_umap.rst
@@ -73,7 +73,7 @@ If you are unfamilar with Tensorflow/Keras and want to train your own model, we 
 Saving and loading your model
 -----------------------------
 
-Unlike non-parametric UMAP Parametric UMAP cannot be saved simply by pickling the UMAP object because of the Keras networks it contains. To save Parametric UMAP, there is a build in function:
+Unlike non-parametric UMAP Parametric UMAP cannot be saved simply by pickling the UMAP object because of the Keras networks it contains. To save Parametric UMAP, there is a built in function:
 
 .. code:: python3
 

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1534,12 +1534,12 @@ class UMAP(BaseEstimator):
     angular_rp_forest: bool (optional, default False)
         Whether to use an angular random projection forest to initialise
         the approximate nearest neighbor search. This can be faster, but is
-        mostly on useful for metric that use an angular style distance such
+        mostly only useful for a metric that uses an angular style distance such
         as cosine, correlation etc. In the case of those metrics angular forests
         will be chosen automatically.
 
     target_n_neighbors: int (optional, default -1)
-        The number of nearest neighbors to use to construct the target simplcial
+        The number of nearest neighbors to use to construct the target simplicial
         set. If set to -1 use the ``n_neighbors`` value.
 
     target_metric: string or callable (optional, default 'categorical')
@@ -1573,7 +1573,7 @@ class UMAP(BaseEstimator):
 
     unique: bool (optional, default False)
         Controls if the rows of your data should be uniqued before being
-        embedded.  If you have more duplicates than you have n_neighbour
+        embedded.  If you have more duplicates than you have ``n_neighbors``
         you can have the identical data points lying in different regions of
         your space.  It also violates the definition of a metric.
         For to map from internal structures back to your data use the variable


### PR DESCRIPTION
Nice library btw :)

This PR fixes a few typos & makes one formatting improvement in the docs