### PR TITLE
fix: fix numpy.int and numpy.float deprecation to be compatible with numpy >= 1.20.0

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2464,7 +2464,7 @@ class UMAP(BaseEstimator):
                 self._knn_indices = np.zeros(
                     (X.shape[0], self.n_neighbors), dtype=int
                 )
-                self._knn_dists = np.zeros(self._knn_indices.shape, dtype=np.float)
+                self._knn_dists = np.zeros(self._knn_indices.shape, dtype=float)
                 for row_id in range(X.shape[0]):
                     # Find KNNs row-by-row
                     row_data = X[row_id].data

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2462,7 +2462,7 @@ class UMAP(BaseEstimator):
                 raise ValueError("Non-zero distances from samples to themselves!")
             if self.knn_dists is None:
                 self._knn_indices = np.zeros(
-                    (X.shape[0], self.n_neighbors), dtype=np.int
+                    (X.shape[0], self.n_neighbors), dtype=int
                 )
                 self._knn_dists = np.zeros(self._knn_indices.shape, dtype=np.float)
                 for row_id in range(X.shape[0]):


### PR DESCRIPTION
Since 1.20.0, numpy has marked np.int and np.float as [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), and since 1.24.0, np.int has been [expired](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations)
Numpy has suggested use `int` to replace `np.int`

related: #1007 