### PR TITLE
Fix unit tests

### DIFF
--- a/umap/spectral.py
+++ b/umap/spectral.py
@@ -6,8 +6,7 @@ import numpy as np
 
 import scipy.sparse
 import scipy.sparse.csgraph
-import sklearn.decomposition
-
+from sklearn.decomposition import TruncatedSVD
 from sklearn.manifold import SpectralEmbedding
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.pairwise import _VALID_METRICS as SKLEARN_PAIRWISE_VALID_METRICS
@@ -226,7 +225,7 @@ def multi_component_layout(
             )
             continue
 
-        diag_data = np.asarray(component_graph.sum(axis=0))
+        diag_data = np.asarray(component_graph.sum(axis=0)).squeeze()
         # standard Laplacian
         # D = scipy.sparse.spdiags(diag_data, 0, graph.shape[0], graph.shape[0])
         # L = D - graph
@@ -278,8 +277,18 @@ def multi_component_layout(
     return result
 
 
-def spectral_layout(data, graph, dim, random_state, metric="euclidean", metric_kwds={}):
-    """Given a graph compute the spectral embedding of the graph. This is
+def spectral_layout(
+    data,
+    graph,
+    dim,
+    random_state,
+    metric="euclidean",
+    metric_kwds={},
+    tol=0.0,
+    maxiter=0
+):
+    """
+    Given a graph compute the spectral embedding of the graph. This is
     simply the eigenvectors of the laplacian of the graph. Here we use the
     normalized laplacian.
 
@@ -297,73 +306,45 @@ def spectral_layout(data, graph, dim, random_state, metric="euclidean", metric_k
     random_state: numpy RandomState or equivalent
         A state capable being used as a numpy random state.
 
+    tol: float, default chosen by implementation
+        Stopping tolerance for the numerical algorithm computing the embedding.
+
+    maxiter: int, default chosen by implementation
+        Number of iterations the numerical algorithm will go through at most as it
+        attempts to compute the embedding.
+
     Returns
     -------
     embedding: array of shape (n_vertices, dim)
         The spectral embedding of the graph.
     """
-    n_samples = graph.shape[0]
-    n_components, labels = scipy.sparse.csgraph.connected_components(graph)
-
-    if n_components > 1:
-        return multi_component_layout(
-            data,
-            graph,
-            n_components,
-            labels,
-            dim,
-            random_state,
-            metric=metric,
-            metric_kwds=metric_kwds,
-        )
-
-    diag_data = np.asarray(graph.sum(axis=0))
-    # standard Laplacian
-    # D = scipy.sparse.spdiags(diag_data, 0, graph.shape[0], graph.shape[0])
-    # L = D - graph
-    # Normalized Laplacian
-    I = scipy.sparse.identity(graph.shape[0], dtype=np.float64)
-    D = scipy.sparse.spdiags(
-        1.0 / np.sqrt(diag_data), 0, graph.shape[0], graph.shape[0]
+    return _spectral_layout(
+        data=data,
+        graph=graph,
+        dim=dim,
+        random_state=random_state,
+        metric=metric,
+        metric_kwds=metric_kwds,
+        init="random",
+        tol=tol,
+        maxiter=maxiter
     )
-    L = I - D * graph * D
-
-    k = dim + 1
-    num_lanczos_vectors = max(2 * k + 1, int(np.sqrt(graph.shape[0])))
-    try:
-        if L.shape[0] < 2000000:
-            eigenvalues, eigenvectors = scipy.sparse.linalg.eigsh(
-                L,
-                k,
-                which="SM",
-                ncv=num_lanczos_vectors,
-                tol=1e-4,
-                v0=np.ones(L.shape[0]),
-                maxiter=graph.shape[0] * 5,
-            )
-        else:
-            eigenvalues, eigenvectors = scipy.sparse.linalg.lobpcg(
-                L, random_state.normal(size=(L.shape[0], k)), largest=False, tol=1e-8
-            )
-        order = np.argsort(eigenvalues)[1:k]
-        return eigenvectors[:, order]
-    except scipy.sparse.linalg.ArpackError:
-        warn(
-            "WARNING: spectral initialisation failed! The eigenvector solver\n"
-            "failed. This is likely due to too small an eigengap. Consider\n"
-            "adding some noise or jitter to your data.\n\n"
-            "Falling back to random initialisation!"
-        )
-        return random_state.uniform(low=-10.0, high=10.0, size=(graph.shape[0], dim))
 
 
 def tswspectral_layout(
-    data, graph, dim, random_state, metric="euclidean", metric_kwds={}
+    data,
+    graph,
+    dim,
+    random_state,
+    metric="euclidean",
+    metric_kwds={},
+    tol=0.0,
+    maxiter=0
 ):
-    """Given a graph compute the spectral embedding of the graph. This is
-    simply the eigenvectors of the laplacian of the graph. Here we use the
+    """Given a graph, compute the spectral embedding of the graph. This is
+    simply the eigenvectors of the Laplacian of the graph. Here we use the
     normalized laplacian and a truncated SVD-based guess of the
-    eigenvectors to "warm" up the lobpcg eigensolver. This function should
+    eigenvectors to "warm" up the eigensolver. This function should
     give results of similar accuracy to the spectral_layout function, but
     may converge more quickly for graph Laplacians that cause
     spectral_layout to take an excessive amount of time to complete.
@@ -394,6 +375,74 @@ def tswspectral_layout(
         Used only if the multiple connected components are found in the
         graph.
 
+    tol: float, default chosen by implementation
+        Stopping tolerance for the numerical algorithm computing the embedding.
+
+    maxiter: int, default chosen by implementation
+        Number of iterations the numerical algorithm will go through at most as it
+        attempts to compute the embedding.
+
+    Returns
+    -------
+    embedding: array of shape (n_vertices, dim)
+        The spectral embedding of the graph.
+    """
+    return _spectral_layout(
+        data=data,
+        graph=graph,
+        dim=dim,
+        random_state=random_state,
+        metric=metric,
+        metric_kwds=metric_kwds,
+        init="tsvd",
+        tol=tol,
+        maxiter=maxiter
+    )
+
+
+def _spectral_layout(
+    data,
+    graph,
+    dim,
+    random_state,
+    metric="euclidean",
+    metric_kwds={},
+    init="random",
+    tol=0.0,
+    maxiter=0
+):
+    """General implementation of the spectral embedding of the graph, derived as
+    a subset of the eigenvectors of the normalized Laplacian of the graph. The numerical
+    method for computing the eigendecomposition is chosen through heuristics.
+
+    Parameters
+    ----------
+    data: array of shape (n_samples, n_features)
+        The source data
+
+    graph: sparse matrix
+        The (weighted) adjacency matrix of the graph as a sparse matrix.
+
+    dim: int
+        The dimension of the space into which to embed.
+
+    random_state: numpy RandomState or equivalent
+        A state capable being used as a numpy random state.
+
+    init: string, either "random" or "tsvd"
+        Indicates to initialize the eigensolver. Use "random" (the default) to
+        use uniformly distributed random initialization; use "tsvd" to warm-start the
+        eigensolver with singular vectors of the Laplacian associated to the largest
+        singular values. This latter option also forces usage of the LOBPCG eigensolver;
+        with the former, ARPACK's solver ``eigsh`` will be used for smaller Laplacians.
+
+    tol: float, default chosen by implementation
+        Stopping tolerance for the numerical algorithm computing the embedding.
+
+    maxiter: int, default chosen by implementation
+        Number of iterations the numerical algorithm will go through at most as it
+        attempts to compute the embedding.
+
     Returns
     -------
     embedding: array of shape (n_vertices, dim)
@@ -414,46 +463,74 @@ def tswspectral_layout(
             metric_kwds=metric_kwds,
         )
 
-    diag_data = np.asarray(graph.sum(axis=0))
-    D = scipy.sparse.spdiags(1.0 / np.sqrt(diag_data), 0, n_samples, n_samples)
-    # L is a shifted version of what we will pass to the eigensolver (I - L)
-    # The eigenvectors of I - L coincide with the first few singular vectors
-    # of L so we can carry out truncated SVD on L to get a guess to pass to lobpcg
-    L = D * graph * D
+    sqrt_deg = np.sqrt(np.asarray(graph.sum(axis=0)).squeeze())
+    # standard Laplacian
+    # D = scipy.sparse.spdiags(diag_data, 0, graph.shape[0], graph.shape[0])
+    # L = D - graph
+    # Normalized Laplacian
+    I = scipy.sparse.identity(graph.shape[0], dtype=np.float64)
+    D = scipy.sparse.spdiags(
+        1.0 / sqrt_deg, 0, graph.shape[0], graph.shape[0]
+    )
+    L = I - D * graph * D
+    if not scipy.sparse.issparse(L):
+        L = np.asarray(L)
 
     k = dim + 1
-    tsvd = sklearn.decomposition.TruncatedSVD(
-        n_components=k, random_state=random_state, algorithm="arpack", tol=1e-2
-    )
-    guess = tsvd.fit_transform(L)
+    num_lanczos_vectors = max(2 * k + 1, int(np.sqrt(graph.shape[0])))
+    gen = np.random.default_rng(seed=random_state)
+    try:
+        if L.shape[0] < 2000000 and init == "random":
+            eigenvalues, eigenvectors = scipy.sparse.linalg.eigsh(
+                L,
+                k,
+                which="SM",
+                ncv=num_lanczos_vectors,
+                tol=tol or 1e-4,
+                v0=np.ones(L.shape[0]),
+                maxiter=maxiter or graph.shape[0] * 5,
+            )
+        else:
+            gen = np.random.default_rng(seed=random_state)
+            if init == "random":
+                X = gen.normal(size=(L.shape[0], k))
+            elif init == "tsvd":
+                X = TruncatedSVD(
+                    n_components=k,
+                    random_state=random_state,
+                    # algorithm="arpack"
+                ).fit_transform(L)
+                # For such a normalized Laplacian, the first eigenvector is always
+                # proportional to sqrt(degrees). We thus replace the first t-SVD guess
+                # with the exact value.
+                X[:, 0] = sqrt_deg / np.linalg.norm(sqrt_deg)
+            else:
+                raise ValueError(
+                    "The init parameter must be either 'random' or 'tsvd': "
+                    f"{init} is invalid."
+                )
 
-    # for a normalized Laplacian, the first eigenvector is always sqrt(D) so replace
-    # the tsvd guess with the exact value. Scaling it to length one seems to help.
-    guess[:, 0] = np.sqrt(diag_data[0] / np.linalg.norm(diag_data[0]))
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    category=UserWarning,
+                    message=r"(?ms).*not reaching the requested tolerance",
+                    action="error"
+                )
+                eigenvalues, eigenvectors = scipy.sparse.linalg.lobpcg(
+                    L,
+                    np.asarray(X),
+                    largest=False,
+                    tol=tol or 1e-4,
+                    maxiter=maxiter or 5 * graph.shape[0]
+                )
 
-    I = scipy.sparse.identity(n_samples, dtype=np.float64)
-
-    # lobpcg emits a UserWarning if convergence was not reached within `maxiter`
-    # so we will just have to catch that instead of an Error
-    # This will also trigger when lobpcg decides the problem size is too small
-    # for it to deal with but there is little chance that this would happen
-    # in most real use cases
-    with warnings.catch_warnings(record=True, category=UserWarning) as warnings_caught:
-        eigenvalues, eigenvectors = scipy.sparse.linalg.lobpcg(
-            np.array(I - L),
-            guess,
-            largest=False,
-            tol=1e-4,
-            maxiter=graph.shape[0] * 5,
-        )
-    if warnings_caught:
+        order = np.argsort(eigenvalues)[1:k]
+        return eigenvectors[:, order]
+    except (scipy.sparse.linalg.ArpackError, UserWarning):
         warn(
-            "WARNING: spectral initialisation failed! The eigenvector solver\n"
+            "Spectral initialisation failed! The eigenvector solver\n"
             "failed. This is likely due to too small an eigengap. Consider\n"
             "adding some noise or jitter to your data.\n\n"
             "Falling back to random initialisation!"
         )
-        return random_state.uniform(low=-10.0, high=10.0, size=(n_samples, dim))
-
-    order = np.argsort(eigenvalues)[1:k]
-    return eigenvectors[:, order]
+        return gen.uniform(low=-10.0, high=10.0, size=(graph.shape[0], dim))

--- a/umap/tests/test_spectral.py
+++ b/umap/tests/test_spectral.py
@@ -1,6 +1,8 @@
 from umap.spectral import spectral_layout, tswspectral_layout
 
 import numpy as np
+import pytest
+from warnings import catch_warnings
 
 
 def test_tsw_spectral_init(iris):
@@ -13,10 +15,25 @@ def test_tsw_spectral_init(iris):
     graph = graph.T * graph
 
     spec = spectral_layout(None, graph, 2, random_state=seed)
-    tsw_spec = tswspectral_layout(None, graph, 2, random_state=seed)
+    tsw_spec = tswspectral_layout(None, graph, 2, random_state=seed, tol=1e-8)
 
     # make sure the two methods produce matrices that are close in values
     rmsd = np.sqrt(np.mean(np.sum((np.abs(spec) - np.abs(tsw_spec)) ** 2, axis=1)))
     assert (
         rmsd < 1e-6
     ), "tsvd-warmed spectral init insufficiently close to standard spectral init"
+
+
+def test_ensure_fallback_to_random_on_spectral_failure():
+    dim = 1000
+    k = 10
+    assert k >= 10
+    assert dim // 10 > k
+    y = np.eye(dim, k=1)
+    u = np.random.random((dim, dim // 10))
+    graph = y + y.T + u @ u.T
+    with pytest.warns(
+        UserWarning,
+        match="Spectral initialisation failed!"
+    ):
+        tswspectral_layout(u, graph, k, random_state=42, maxiter=2)

--- a/umap/tests/test_spectral.py
+++ b/umap/tests/test_spectral.py
@@ -2,7 +2,11 @@ from umap.spectral import spectral_layout, tswspectral_layout
 
 import numpy as np
 import pytest
+from scipy.version import full_version as scipy_full_version_
 from warnings import catch_warnings
+
+
+scipy_full_version = tuple(int(n) for n in scipy_full_version_.split("."))
 
 
 def test_tsw_spectral_init(iris):
@@ -24,6 +28,10 @@ def test_tsw_spectral_init(iris):
     ), "tsvd-warmed spectral init insufficiently close to standard spectral init"
 
 
+@pytest.mark.skipif(
+    scipy_full_version < (1, 10),
+    reason="SciPy installing with Py 3.7 does not warn reliably on convergence failure"
+)
 def test_ensure_fallback_to_random_on_spectral_failure():
     dim = 1000
     k = 10

--- a/umap/tests/test_spectral.py
+++ b/umap/tests/test_spectral.py
@@ -9,6 +9,10 @@ from warnings import catch_warnings
 scipy_full_version = tuple(int(n) for n in scipy_full_version_.split("."))
 
 
+@pytest.mark.skipif(
+    scipy_full_version < (1, 10),
+    reason="SciPy installing with Python 3.7 does not converge under same circumstances"
+)
 def test_tsw_spectral_init(iris):
     # create an arbitrary (dense) random affinity matrix
     seed = 42

--- a/umap/tests/test_umap_metrics.py
+++ b/umap/tests/test_umap_metrics.py
@@ -5,9 +5,11 @@ import umap.sparse as spdist
 
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import BallTree
-from scipy.version import full_version as scipy_full_version
+from scipy.version import full_version as scipy_full_version_
 import pytest
 
+
+scipy_full_version = tuple(int(n) for n in scipy_full_version_.split("."))
 
 
 # ===================================================
@@ -212,6 +214,9 @@ def test_dice(binary_data, binary_distances):
     binary_check("dice", binary_data, binary_distances)
 
 
+@pytest.mark.skipif(
+    scipy_full_version >= (1, 9), reason="deprecated in SciPy 1.9, removed in 1.11"
+)
 def test_kulsinski(binary_data, binary_distances):
     binary_check("kulsinski", binary_data, binary_distances)
 
@@ -294,6 +299,9 @@ def test_sparse_dice(sparse_binary_data):
     sparse_binary_check("dice", sparse_binary_data)
 
 
+@pytest.mark.skipif(
+    scipy_full_version >= (1, 9), reason="deprecated in SciPy 1.9, removed in 1.11"
+)
 def test_sparse_kulsinski(sparse_binary_data):
     sparse_binary_check("kulsinski", sparse_binary_data)
 
@@ -336,7 +344,7 @@ def test_seuclidean(spatial_data):
     )
 
 @pytest.mark.skipif(
-    scipy_full_version < "1.8", reason="incorrect function in scipy<1.8"
+    scipy_full_version < (1, 8), reason="incorrect function in scipy<1.8"
 )
 def test_weighted_minkowski(spatial_data):
     v = np.abs(np.random.randn(spatial_data.shape[1]))
@@ -493,7 +501,7 @@ def test_grad_metrics_match_metrics(spatial_data, spatial_distances):
         err_msg="Distances don't match " "for metric seuclidean",
     )
 
-    if scipy_full_version >= "1.8":
+    if scipy_full_version >= (1, 8):
         # Weighted minkowski
         dist_matrix = pairwise_distances(spatial_data, metric="minkowski", w=v, p=3)
         test_matrix = np.array(

--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -261,7 +261,7 @@ def test_precomputed_knn_on_iris(iris, iris_selection, iris_subset_model):
             **umap_args,
             precomputed_knn=(knn[0], knn[1]),
         ).fit(data)
-        assert len(record) == 1
+        assert len(record) >= 1
     np.testing.assert_array_equal(
         fitter_ignoring_force_approx.embedding_, fitter_with_precomputed_knn.embedding_
     )
@@ -278,7 +278,7 @@ def test_precomputed_knn_on_iris(iris, iris_selection, iris_subset_model):
             precomputed_knn=(knn[0], knn[1]),
             force_approximation_algorithm=True,
         ).fit(data)
-        assert len(record) == 1
+        assert len(record) >= 1
     np.testing.assert_array_equal(
         fitter_ignoring_force_approx_True.embedding_, fitter_ignoring_force_approx.embedding_
     )

--- a/umap/tests/test_umap_ops.py
+++ b/umap/tests/test_umap_ops.py
@@ -47,7 +47,7 @@ def test_blobs_cluster():
 # Multi-components Layout
 def test_multi_component_layout():
     data, labels = make_blobs(
-        100, 2, centers=5, cluster_std=0.5, center_box=[-20, 20], random_state=42
+        100, 2, centers=5, cluster_std=0.5, center_box=(-20, 20), random_state=42
     )
 
     true_centroids = np.empty((labels.max() + 1, data.shape[1]), dtype=np.float64)
@@ -74,7 +74,7 @@ def test_multi_component_layout():
 # Multi-components Layout
 def test_multi_component_layout_precomputed():
     data, labels = make_blobs(
-        100, 2, centers=5, cluster_std=0.5, center_box=[-20, 20], random_state=42
+        100, 2, centers=5, cluster_std=0.5, center_box=(-20, 20), random_state=42
     )
     dmat = pairwise_distances(data)
 


### PR DESCRIPTION
This PR fixes unit tests that had decayed because of some unsound warning handling and deprecations in dependency calling contracts. It also refactors the `umap.spectral` comprehensively, removing code duplication and improving the legibility of alternative approaches to spectral initialization of the low-space embedding.