### PR TITLE
Drop requirements.txt, embrace setup.py for deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Recommended packages:
    * matplotlib
    * datashader
    * holoviews
-* for Parametric UMAP  
+* for Parametric UMAP
    * tensorflow > 2.0.0
 
 **Install Options**
@@ -131,8 +131,8 @@ If you wish to use the plotting functionality you can use
 to install all the plotting dependencies.
 
 If you wish to use Parametric UMAP, you need to install Tensorflow, which can be
-installed either using the instructions at https://www.tensorflow.org/install 
-(reccomended) or using 
+installed either using the instructions at https://www.tensorflow.org/install
+(reccomended) or using
 
 .. code:: bash
 
@@ -159,23 +159,17 @@ For a manual install get this package:
     rm master.zip
     cd umap-master
 
-Install the requirements
-
-.. code:: bash
-
-    sudo pip install -r requirements.txt
-
-or
+Optionally, install the requirements through Conda:
 
 .. code:: bash
 
     conda install scikit-learn numba
 
-Install the package
+Then install the package
 
 .. code:: bash
 
-    python setup.py install
+    python -m pip install -e .
 
 ---------------
 How to use UMAP
@@ -293,7 +287,7 @@ For a problem such as the 784-dimensional MNIST digits dataset with
 compared with around 45 minutes for scikit-learn's t-SNE implementation).
 Despite this runtime efficiency, UMAP still produces high quality embeddings.
 
-The obligatory MNIST digits dataset, embedded in 42 
+The obligatory MNIST digits dataset, embedded in 42
 seconds (with pynndescent installed and after numba jit warmup)
 using a 3.1 GHz Intel Core i7 processor (n_neighbors=10, min_dist=0.001):
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,14 +28,10 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
-
-      - script: |
           pip install -e .
           pip install .[plot]
           pip install .[parametric_umap]
-        displayName: 'Install package'
+        displayName: 'Install package and its dependencies'
 
       - script: |
           pip install pytest pytest-benchmark
@@ -68,14 +64,10 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
-
-      - script: |
           pip install -e .
           pip install .[plot]
           pip install .[parametric_umap]
-        displayName: 'Install package'
+        displayName: 'Install package and its dependencies'
 
       - script: |
           pip install pytest pytest-benchmark
@@ -108,14 +100,10 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
-
-      - script: |
           pip install -e .
           pip install .[plot]
           pip install .[parametric_umap]
-        displayName: 'Install package'
+        displayName: 'Install package and its dependencies'
 
       - script: |
           pip install pytest pytest-benchmark
@@ -144,17 +132,13 @@ jobs:
 
       - script: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
-
-      - script: |
           pip install -e .
           pip install .[plot]
           pip install .[parametric_umap]
           pip install pytest pytest-benchmark
           pip install pytest-cov
           pip install coveralls
-        displayName: 'Install package'
+        displayName: 'Install package and its dependencies'
 
       - script: |
           export NUMBA_DISABLE_JIT=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-numpy>=1.17
-scipy>=1.3.1
-scikit-learn>=0.22
-numba>=0.51.2
-pynndescent>=0.5
-tbb>=2019.0
-tqdm


### PR DESCRIPTION
File requirements.txt duplicates the UMAP dependency information that we must put in setup.py. It makes sense then to drop it, and to trust the installation of the UMAP package as sufficient for setting up its own dependencies. The README is updated in this sense, and the CI pipelines are streamlined.