### PR TITLE
Drop dependency on TBB on non-Intel deployments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import platform
 from setuptools import setup
 
 
@@ -49,9 +50,8 @@ configuration = {
         "scikit-learn >= 0.22",
         "numba >= 0.51.2",
         "pynndescent >= 0.5",
-        "tbb >= 2019.0",
         "tqdm",
-    ],
+    ] + (["tbb >= 2019.0"] if platform.machine().lower().startswith("x86") else []),
     "extras_require": {
         "plot": [
             "pandas",


### PR DESCRIPTION
The project depends on package `tbb', short for Intel's Thread Building Blocks. Obviously, this cannot possibly install on to ARM processors. This PR arranges for the setup script to include the dependency only on Intel-based machines (regardless of OS).