### PR TITLE
fix interactive plot if hover_data but no tools is provided

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1446,7 +1446,7 @@ def interactive(
                 data[col_name] = hover_data[col_name]
                 tooltip_dict[col_name] = "@{" + col_name + "}"
             tooltips = list(tooltip_dict.items())
-            
+
             if tools is not None:
                 for _tool in tools:
                     if _tool.__class__.__name__ == "HoverTool":

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -1446,11 +1446,12 @@ def interactive(
                 data[col_name] = hover_data[col_name]
                 tooltip_dict[col_name] = "@{" + col_name + "}"
             tooltips = list(tooltip_dict.items())
-
-            for _tool in tools:
-                if _tool.__class__.__name__ == "HoverTool":
-                    tooltip_needed = False
-                    break
+            
+            if tools is not None:
+                for _tool in tools:
+                    if _tool.__class__.__name__ == "HoverTool":
+                        tooltip_needed = False
+                        break
 
         if alpha is not None:
             data["alpha"] = alpha


### PR DESCRIPTION
fixes
https://github.com/lmcinnes/umap/issues/1057#issue-1913435549

```plot.py:1450, in interactive(umap_object, labels, values, hover_data, tools, theme, cmap, color_key, color_key_cmap, background, width, height, point_size, subset_points, interactive_text_search, interactive_text_search_columns, interactive_text_search_alpha_contrast, alpha)
   1447     tooltip_dict[col_name] = "@{" + col_name + "}"
   1448 tooltips = list(tooltip_dict.items())
-> 1450 for _tool in tools:
   1451     if _tool.__class__.__name__ == "HoverTool":
   1452         tooltip_needed = False

TypeError: 'NoneType' object is not iterable```