### PR TITLE
Remove relative import from test

### DIFF
--- a/umap/tests/test_umap_get_feature_names_out.py
+++ b/umap/tests/test_umap_get_feature_names_out.py
@@ -2,7 +2,7 @@ import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.pipeline import Pipeline, FeatureUnion
 
-from ..umap_ import UMAP
+from umap.umap_ import UMAP
 
 
 def test_get_feature_names_out_passthrough():


### PR DESCRIPTION
The relative import causes some import errors with `umap_` not being found when the tests are run from some test environments.