### PR TITLE
Make `tbb` requirement optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,13 @@ installed either using the instructions at https://www.tensorflow.org/install
 
 for a CPU-only version of Tensorflow.
 
+If you're on an x86 processor, you can also optionally install `tbb`, which will
+provide additional CPU optimizations:
+
+.. code:: bash
+
+    pip install umap-learn[tbb]
+
 If pip is having difficulties pulling the dependencies then we'd suggest installing
 the dependencies manually using anaconda followed by pulling umap from pip:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,10 @@ stages:
             pip install -e .
             pip install .[plot]
             pip install .[parametric_umap]
-            if [ `uname -m` = x86_64 ]; then; pip install .[tbb]; fi
+            if [ `uname -m` = x86_64 ]
+            then
+            pip install .[tbb]
+            fi
             pip install pytest  pytest-azurepipelines pytest-cov pytest-benchmark coveralls
           displayName: 'Install package'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,10 +78,6 @@ stages:
             pip install -e .
             pip install .[plot]
             pip install .[parametric_umap]
-            if [ `uname -m` = x86_64 ]
-            then
-            pip install .[tbb]
-            fi
             pip install pytest  pytest-azurepipelines pytest-cov pytest-benchmark coveralls
           displayName: 'Install package'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,7 @@ stages:
             pip install -e .
             pip install .[plot]
             pip install .[parametric_umap]
+            if [ `uname -m` = x86_64 ]; then; pip install .[tbb]; fi
             pip install pytest  pytest-azurepipelines pytest-cov pytest-benchmark coveralls
           displayName: 'Install package'
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ configuration = {
         "numba >= 0.51.2",
         "pynndescent >= 0.5",
         "tqdm",
-    ] + (["tbb >= 2019.0"] if platform.machine().lower().startswith("x86") else []),
+    ],
     "extras_require": {
         "plot": [
             "pandas",
@@ -64,6 +64,7 @@ configuration = {
             "scikit-image",
         ],
         "parametric_umap": ["tensorflow >= 2.1", "tensorflow-probability >= 0.10"],
+        "x86": ["tbb >= 2019.0"],
     },
     "ext_modules": [],
     "cmdclass": {},

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 configuration = {
     "name": "umap-learn",
-    "version": "0.5.4+dd.1",
+    "version": "0.5.4",
     "description": "Uniform Manifold Approximation and Projection",
     "long_description": readme(),
     "long_description_content_type": "text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ configuration = {
             "scikit-image",
         ],
         "parametric_umap": ["tensorflow >= 2.1", "tensorflow-probability >= 0.10"],
-        "x86": ["tbb >= 2019.0"],
+        "tbb": ["tbb >= 2019.0"],
     },
     "ext_modules": [],
     "cmdclass": {},

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 configuration = {
     "name": "umap-learn",
-    "version": "0.5.4",
+    "version": "0.5.4+dd.1",
     "description": "Uniform Manifold Approximation and Projection",
     "long_description": readme(),
     "long_description_content_type": "text/x-rst",


### PR DESCRIPTION
As discussed in #1060, makes `tbb` an optional dependency that will only be installed manually, and adds a documentation section describing it.