### PR TITLE
Fixed bug causing digits data bokeh plot in tutorial to break

### DIFF
--- a/doc/basic_usage.rst
+++ b/doc/basic_usage.rst
@@ -522,8 +522,8 @@ that are hard even for humans to classify correctly).
     
     plot_figure = figure(
         title='UMAP projection of the Digits dataset',
-        plot_width=600,
-        plot_height=600,
+        width=600,
+        height=600,
         tools=('pan, wheel_zoom, reset')
     )
     


### PR DESCRIPTION
# Issue
On a fresh install of bokeh 3.3.0 the using `plot_width` and `plot_height` results in the following error:

`AttributeError: unexpected attribute 'plot_width' to figure, similar attributes are outer_width, width or min_width`

## Technical information
- bokeh 3.3.0
- pip 23.2.1
- jupyter_core 5.3.1
- jupyter_client 8.3.1

Running in a VSCode Jupyter notebook:
- Jupyter notebook VSCode extension v2023.9.1102792234
- VSCode September 2023 (version 1.83)

Installed in Windows 11 directly (not running on WSL).

# Fix
Use `width` and `height` instead which are equivalents according to the [bokeh documentation.](https://docs.bokeh.org/en/2.4.0/docs/reference/plotting/figure.html#bokeh.plotting.Figure.plot_width)

# Why is this useful
Ensuring the tutorial/demo works seamlessly leads to a better onboarding experience for new users and better retention.


