### PR TITLE
Fix `pkg_resources` deprecation warning

### DIFF
--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -33,9 +33,9 @@ from .aligned_umap import AlignedUMAP
 # Workaround: https://github.com/numba/numba/issues/3341
 import numba
 
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = pkg_resources.get_distribution("umap-learn").version
-except pkg_resources.DistributionNotFound:
+    __version__ = version("umap-learn")
+except PackageNotFoundError:
     __version__ = "0.5-dev"


### PR DESCRIPTION
The package `pkg_resources` is deprecated. This PR implements using `importlib` instead for getting the version number.