### PR TITLE
Setting random state could still lead to stochastic results

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1940,6 +1940,7 @@ class UMAP(BaseEstimator):
         if self.n_jobs < -1 or self.n_jobs == 0:
             raise ValueError("n_jobs must be a postive integer, or -1 (for all cores)")
         if self.n_jobs != 1 and self.random_state is not None:
+            self.n_jobs = 1
             warn(f"n_jobs value {self.n_jobs} overridden to 1 by setting random_state. Use no seed for parallelism.") 
 
         if self.dens_lambda < 0.0:


### PR DESCRIPTION
Issue #1080

When setting a random state, results should be reproducible, as explained in the documentation:
https://umap-learn.readthedocs.io/en/latest/reproducibility.html

Setting a random state should mean that parallelization is disabled, however, this is not the case. Only a warning is given, but no where self.n_jobs gets set to 1.
Line 1943: `warn(f"n_jobs value {self.n_jobs} overridden to 1 by setting random_state. Use no seed for parallelism.")`

This PR resolves this issue by actually setting self.n_jobs to 1 when a random state is set.