### PR TITLE
Add torch support to ParametricUMAP

### DIFF
--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -105,7 +105,8 @@ class ParametricUMAP(UMAP):
         self.keras_fit_kwargs = keras_fit_kwargs  # arguments for model.fit
         self.parametric_model = None
 
-        # How many epochs to train for (different than n_epochs which is specific to each sample)
+        # How many epochs to train for
+        # (different than n_epochs which is specific to each sample)
         self.n_training_epochs = 1
 
         # Set optimizer.
@@ -622,7 +623,7 @@ def umap_loss(
             )
         else:
             embedding_neg_from = repeat_neg[shuffled_indices]
-            
+
         # embedding_neg_from = keras.random.shuffle(repeat_neg, axis=0)
 
         #  distances between samples (and negative samples)
@@ -641,7 +642,11 @@ def umap_loss(
 
         # set true probabilities based on negative sampling
         probabilities_graph = ops.concatenate(
-            [ops.ones((batch_size,)), ops.zeros((batch_size * negative_sample_rate,))], axis=0
+            [
+                ops.ones((batch_size,)),
+                ops.zeros((batch_size * negative_sample_rate,)),
+            ],
+            axis=0
         )
 
         # compute cross entropy


### PR DESCRIPTION
This is a follow-up CL to #1101. It makes the code backend-agnostic and unlocks PyTorch support. It also removes some amount of unused code as well as a couple of constructor arguments identified as unnecessary.

Notes:

- This restricts support to Keras 3 only. IMO this is not a problem because Keras 2 is now considered legacy, and those who need to use it can simply stick to an earlier version of umap-learn. Supporting both backend-agnostic Keras 3 AND Keras 2 would be complex. It's easy to support either {Keras 2, Keras 3 + TF} or {Keras 3 + any backend}, but not the union of both sets.
- TF is still needed for the tf.data pipeline. We could change that in the future, though. There's no actual need to use tf.data.
- JAX isn't yet supported, due to one line in the umap loss that calls a RNG function (shuffle). JAX is stateless so the RNG call needs to be made stateless. We can do this easily via the model-centric refactor proposed in https://github.com/lmcinnes/umap/pull/1101#issuecomment-2005717945.
- In order not to break PyTorch support going forward, you would need to start running the ParametricUMAP tests with the PyTorch backend too. Right now the PyTorch backend won't be tested on CI so it might break upon future changes.
- We still need to perform the refactors from https://github.com/lmcinnes/umap/pull/1101#issuecomment-2005717945 for code health.