### PR TITLE
Enhance Compatibility for Python Versions Below 3.8

### DIFF
--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -33,7 +33,10 @@ from .aligned_umap import AlignedUMAP
 # Workaround: https://github.com/numba/numba/issues/3341
 import numba
 
-from importlib.metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError  # Python 3.8+
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError  # Python < 3.8
 
 try:
     __version__ = version("umap-learn")


### PR DESCRIPTION
Hi, 
I've popped in a pull request to propose a small yet significant enhancement to the [umap package/project]. This enhancement aims to improve the package's compatibility with Python versions below 3.8, ensuring a broader user base can benefit from its powerful features without facing import errors.

Currently, the package utilizes `importlib.metadata` for importing `version` and `PackageNotFoundError`, which is available in Python 3.8 and newer versions. However, this leads to compatibility issues with older Python versions, as they lack this module, potentially alienating a segment of the user base still on these versions.

To address this issue, I have implemented a conditional import strategy in the `__init__.py` file. The code attempts to import `version` and `PackageNotFoundError` from `importlib.metadata` (available in Python 3.8+). If this import fails (indicating the user is on an older Python version), it falls back to importing the same modules from the `importlib_metadata` package, which is a backport of `importlib.metadata` for older Python versions.