### PR TITLE
[BUG]: Fix feature names for sklearn API

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -8,8 +8,8 @@ from warnings import warn
 import time
 
 from scipy.optimize import curve_fit
-from sklearn.base import BaseEstimator
-from sklearn.utils import check_random_state, check_array
+from sklearn.base import BaseEstimator, ClassNamePrefixFeaturesOutMixin
+from sklearn.utils import check_array, check_random_state
 from sklearn.utils.validation import check_is_fitted
 from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import normalize
@@ -1408,7 +1408,7 @@ def find_ab_params(spread, min_dist):
     return params[0], params[1]
 
 
-class UMAP(BaseEstimator):
+class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
     """Uniform Manifold Approximation and Projection
 
     Finds a low dimensional embedding of the data that approximates
@@ -2855,6 +2855,9 @@ class UMAP(BaseEstimator):
         numba.set_num_threads(self._original_n_threads)
         self._input_hash = joblib.hash(self._raw_data)
 
+        # Set number of features out for sklearn API
+        self._n_features_out = self.embedding_.shape[1]
+
         return self
 
     def _fit_embed_data(self, X, n_epochs, init, random_state, **kwargs):
@@ -3577,19 +3580,6 @@ class UMAP(BaseEstimator):
         if self.output_dens:
             self.rad_orig_ = aux_data["rad_orig"]
             self.rad_emb_ = aux_data["rad_emb"]
-
-    def get_feature_names_out(self, feature_names_out=None):
-        """
-        Defines descriptive names for each output of the (fitted) estimator.
-        :param feature_names_out: Optional passthrough for feature names.
-        By default, feature names will be generated automatically.
-        :return: List of descriptive names for each output variable from the fitted estimator.
-        """
-        if feature_names_out is None:
-            feature_names_out = [
-                f"umap_component_{i+1}" for i in range(self.n_components)
-            ]
-        return feature_names_out
 
     def __repr__(self):
         from sklearn.utils._pprint import _EstimatorPrettyPrinter


### PR DESCRIPTION
This PR fixes the bug described in #1082.

Indeed, current `UMAP` scikit-learn compatible class does not support using pandas dataframes as it will output the input features names.

The fix is to use the `ClassNamePrefixFeaturesOutMixin` and set the `_n_features_out` attribute after fitting.

This will give feature names `umap0`, `umap1`, etc... following what scikit-learn does for the dimensionality reduction transformers.