### PR TITLE
Update basic_usage.rst to replace deprecated function.

### DIFF
--- a/doc/basic_usage.rst
+++ b/doc/basic_usage.rst
@@ -539,7 +539,7 @@ that are hard even for humans to classify correctly).
     </div>
     """))
     
-    plot_figure.circle(
+    plot_figure.scatter(
         'x',
         'y',
         source=datasource,


### PR DESCRIPTION
Minor doc update to replace circle() with scatter().