### PR TITLE
feat: generate embedding from index and initialization

### DIFF
--- a/examples/index_fit_example.py
+++ b/examples/index_fit_example.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from sklearn.decomposition import PCA
+import umap
+from sklearn.datasets import fetch_openml
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+# install hnswlib with pip install hnswlib
+# or update to use any other index (e.g., nndescent)
+import hnswlib
+
+sns.set(context="paper", style="white")
+
+mnist = fetch_openml("mnist_784", version=1)
+
+sample_size = 70000
+
+# create a knn index
+knn_index = hnswlib.Index(space='l2', dim=mnist.data.shape[1])
+knn_index.init_index(max_elements=sample_size, ef_construction=100, M=16)
+knn_index.add_items(mnist.data.values[:sample_size])
+
+knn_indices, knn_dists = knn_index.knn_query(mnist.data.values[:sample_size], k=15)
+
+
+pca_init = PCA(n_components=2).fit_transform(mnist.data.values[:sample_size])
+
+reducer = umap.UMAP(random_state=42, n_neighbors=15, 
+                    precomputed_knn=(knn_indices, knn_dists), 
+                    verbose=True, n_jobs=-1, init=pca_init, metric="euclidean")
+embedding = reducer.fit_transform_index()
+
+fig, ax = plt.subplots(figsize=(12, 10))
+color = mnist.target[:sample_size].astype(int)
+plt.scatter(embedding[:, 0], embedding[:, 1], c=color, cmap="Spectral", s=0.1)
+plt.setp(ax, xticks=[], yticks=[])
+plt.title("MNIST data embedded into two dimensions by UMAP", fontsize=18)
+
+plt.show()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 configuration = {
     "name": "umap-learn",
-    "version": "0.6.0",
+    "version": "0.5.8",
     "description": "Uniform Manifold Approximation and Projection",
     "long_description": readme(),
     "long_description_content_type": "text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 configuration = {
     "name": "umap-learn",
-    "version": "0.5.8",
+    "version": "0.6.0",
     "description": "Uniform Manifold Approximation and Projection",
     "long_description": readme(),
     "long_description_content_type": "text/x-rst",

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1822,7 +1822,7 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
             self._target_metric_kwds = self.target_metric_kwds
         # check sparsity of data upfront to set proper _input_distance_func &
         # save repeated checks later on
-        if self._raw_data and scipy.sparse.isspmatrix_csr(self._raw_data):
+        if self._raw_data is not None and scipy.sparse.isspmatrix_csr(self._raw_data):
             self._sparse_data = True
         else:
             self._sparse_data = False
@@ -2021,7 +2021,7 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
                 self.knn_indices = None
                 self.knn_dists = None
                 self.knn_search_index = None
-            elif self._raw_data and self.knn_dists.shape[0] != self._raw_data.shape[0]:
+            elif self._raw_data is not None and self.knn_dists.shape[0] != self._raw_data.shape[0]:
                 warn(
                     "precomputed_knn has a different number of samples than the"
                     " data you are fitting. precomputed_knn will be ignored and"


### PR DESCRIPTION
This PR aims to reduce memory usage when an index is pre built for the input data. The user is able to generate an embedding given the precomputed index and initialization.

* Generates embeddings using `precomputed_knn` and `init (np.array)`;
* Refactors `fuzzy_simplicial_set` by pulling out `nearest_neighbor` call (so we don't require passing the input data);
* Usage example