### PR TITLE
Add support for python 3.13 to build pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,17 @@ stages:
             windows_py312:
               imageName: 'windows-latest'
               python.version: '3.12'
-
+            # # Disable macOS tests on 3.13 since tensorflow only provides pre-built wheels
+            # # for ARM macs and the runner is x86
+            # mac_py313:
+            #   imageName: 'macOS-latest'
+            #   python.version: '3.13'
+            linux_py313:
+              imageName: 'ubuntu-latest'
+              python.version: '3.13'
+            windows_py313:
+              imageName: 'windows-latest'
+              python.version: '3.13'
         pool:
           vmImage: $(imageName)
 
@@ -110,7 +120,10 @@ stages:
         - bash: |
             coveralls
           displayName: 'Publish to coveralls'
-          condition: and(succeeded(), eq(variables.triggeredByPullRequest, false)) # Don't run this for PRs because they can't access pipeline secrets
+          # Don't run this for PRs because they can't access pipeline secrets
+          # The python client for coveralls currently does not support python 3.13
+          # https://github.com/TheKevJames/coveralls-python/pull/542
+          condition: and(succeeded(), eq(variables.triggeredByPullRequest, false), ne(variables['python.version'], '3.13'))
           env:
             COVERALLS_REPO_TOKEN: $(COVERALLS_TOKEN)
 


### PR DESCRIPTION
Tensorflow recently added support for python 3.13 so I've added it to the build pipelines. Unfortunately they only have wheels for ARM based macs and the macOS runner is x86. I think an ARM based mac runner will come eventually so we can turn that on then.

The python coveralls client doesn't support 3.13 so I've disabled it just for that. You can still see the test coverage for other versions (and in the azure devops UI)