### PR TITLE
Fix typo in the dataset explanation paragraph

### DIFF
--- a/doc/basic_usage.rst
+++ b/doc/basic_usage.rst
@@ -177,8 +177,8 @@ of bill (culmen) and flippers and weights of three species of penguins,
 along with some other metadata about the penguins. In total we have 333
 different penguins measured. Visualizing this data is a little bit
 tricky since we can't plot in 4 dimensions easily. Fortunately four is
-not that large a number, so we can just to a pairwise feature
-scatterplot matrix to get an ideas of what is going on. Seaborn makes
+not that large a number, so we can just do a pairwise feature
+scatterplot matrix to get an idea of what is going on. Seaborn makes
 this easy.
 
 .. code:: python3


### PR DESCRIPTION
Fixed some typos in the paragraph explaining the dataset in basic_usage.rst.