### PR TITLE
Deterministic sort for fast_knn_indices

### DIFF
--- a/umap/utils.py
+++ b/umap/utils.py
@@ -31,7 +31,7 @@ def fast_knn_indices(X, n_neighbors):
     knn_indices = np.empty((X.shape[0], n_neighbors), dtype=np.int32)
     for row in numba.prange(X.shape[0]):
         # v = np.argsort(X[row])  # Need to call argsort this way for numba
-        v = X[row].argsort(kind="quicksort")
+        v = X[row].argsort(kind="mergesort")
         v = v[:n_neighbors]
         knn_indices[row] = v
     return knn_indices


### PR DESCRIPTION
This makes tests using UMAP less flaky because ties will be returned in the same order.

This may have a performance impact. If performance is critical here, using np.argpartition would be a better solution (only sorts the first k items) but wouldn't address the deterministic sorting issue.

https://github.com/lmcinnes/umap/issues/1235