### PR TITLE
Fix _select_font_color ValueError on hex backgrounds

### DIFF
--- a/umap/plot.py
+++ b/umap/plot.py
@@ -238,7 +238,7 @@ def _select_font_color(background):
         font_color = "white"
     elif background.startswith("#"):
         mean_val = np.mean(
-            [int("0x" + c) for c in (background[1:3], background[3:5], background[5:7])]
+            [int(c, 16) for c in (background[1:3], background[3:5], background[5:7])]
         )
         if mean_val > 126:
             font_color = "black"


### PR DESCRIPTION
Fixes #1231.

`umap.plot._select_font_color` raises `ValueError: invalid literal for int() with base 10: '0xff'` for any hex background color, because `int("0x" + c)` calls `int()` in base 10. Replaced with `int(c, 16)`, which parses the 2-char hex component directly.

```python
from umap.plot import _select_font_color

# before
_select_font_color("#ffffff")
# ValueError: invalid literal for int() with base 10: '0xff'

# after
_select_font_color("#ffffff")
# 'black'
```