### PR TITLE
Add py.typed marker for type checkers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,4 @@ zip-safe = false
 
 [tool.setuptools.package-data]
 "*" = ["*.pyx", "*.pxd"]
+"umap" = ["py.typed"]


### PR DESCRIPTION
Fixes #1177.

Adds an empty `umap/py.typed` marker (per PEP 561) and includes it in setuptools `package-data` so it ships with the wheel. Type checkers like `mypy` now recognise `umap` as a typed package instead of emitting:

```
error: Skipping analyzing "umap": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

The package doesn't ship full annotations yet, so this is just the marker — it lets downstream users drop `ignore_missing_imports` overrides for `umap`.