### PR TITLE
Preserve input dtype in transform and fit_transform output

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2931,12 +2931,16 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
         r_emb: array, shape (n_samples)
             Local radii of data points in the embedding (log-transformed).
         """
+        _input_dtype = getattr(X, "dtype", None)
         self.fit(X, y, ensure_all_finite, **kwargs)
         if self.transform_mode == "embedding":
+            embedding = self.embedding_
+            if _input_dtype is not None and np.issubdtype(_input_dtype, np.floating):
+                embedding = embedding.astype(_input_dtype, copy=False)
             if self.output_dens:
-                return self.embedding_, self.rad_orig_, self.rad_emb_
+                return embedding, self.rad_orig_, self.rad_emb_
             else:
-                return self.embedding_
+                return embedding
         elif self.transform_mode == "graph":
             return self.graph_
         else:
@@ -2966,6 +2970,7 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
         X_new : array, shape (n_samples, n_components)
             Embedding of the new data in low-dimensional space.
         """
+        _input_dtype = getattr(X, "dtype", None)
         # If we fit just a single instance then error
         if self._raw_data.shape[0] == 1:
             raise ValueError(
@@ -2987,7 +2992,12 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
         x_hash = joblib.hash(X)
         if x_hash == self._input_hash:
             if self.transform_mode == "embedding":
-                return self.embedding_
+                embedding = self.embedding_
+                if _input_dtype is not None and np.issubdtype(
+                    _input_dtype, np.floating
+                ):
+                    embedding = embedding.astype(_input_dtype, copy=False)
+                return embedding
             elif self.transform_mode == "graph":
                 return self.graph_
             else:
@@ -3184,6 +3194,8 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
                 tqdm_kwds=self.tqdm_kwds,
             )
 
+        if _input_dtype is not None and np.issubdtype(_input_dtype, np.floating):
+            embedding = embedding.astype(_input_dtype, copy=False)
         return embedding
 
     def inverse_transform(self, X):


### PR DESCRIPTION
Fixes #1240.

`UMAP.transform` and `UMAP.fit_transform` currently downcast the returned embedding to `float32` even when the input array is `float64`, because `check_array(..., dtype=np.float32)` coerces X before the optimizer runs. This matches UMAP's internal numba precision but diverges from scikit-learn's `PCA`, which preserves the input floating dtype. The inconsistency causes small numerical differences downstream and breaks tests that compare UMAP output to `float64` expectations.

The fix captures `X.dtype` before `check_array` and, if it is a floating-point dtype, casts the returned embedding back to it at each embedding return point (`fit_transform`, the `transform` short-circuit when `x_hash == self._input_hash`, and the normal `transform` path). Non-floating inputs (int, bool, ...) keep the current `float32` behaviour, and graph outputs are untouched.

Repro from the issue:

```python
import numpy as np
from umap import UMAP

rng = np.random.default_rng(1)
x = rng.random(size=(800, 80), dtype=np.float64)

m = UMAP(random_state=1, n_components=2)
print(m.fit_transform(x).dtype)   # before: float32   after: float64
print(m.transform(x).dtype)       # before: float32   after: float64
```

\`float32\` input still returns \`float32\`, and integer input still returns \`float32\` (unchanged from current behaviour).

Two things worth calling out, both of which match how sklearn \`PCA\` already behaves:

- **float16 input**: the final embedding is computed in \`float32\` internally and then cast down to \`float16\` on return, so callers passing \`float16\` will see some precision loss on the output. Same as \`PCA\` on a \`float16\` input.
- **float64 input, large N**: the returned embedding doubles in memory compared to the old \`float32\` output. Correct behaviour and what the issue asks for, but anyone who was implicitly relying on \`float32\` as a memory ceiling will want to \`.astype(np.float32)\` after \`transform\` to get the old footprint back.