### PR TITLE
Optimize BFS and init_graph_transform in fit/transform pipeline

### DIFF
--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import locale
+from collections import deque
 from warnings import warn
 import time
 
@@ -84,14 +85,13 @@ def flattened(container):
 
 def breadth_first_search(adjmat, start, min_vertices):
     explored = []
-    queue = [start]
-    levels = {}
-    levels[start] = 0
+    queue = deque([start])
+    levels = {start: 0}
     max_level = np.inf
-    visited = [start]
+    visited = {start}
 
     while queue:
-        node = queue.pop(0)
+        node = queue.popleft()
         explored.append(node)
         if max_level == np.inf and len(explored) > min_vertices:
             max_level = max(levels.values())
@@ -101,7 +101,7 @@ def breadth_first_search(adjmat, start, min_vertices):
             for neighbour in neighbors:
                 if neighbour not in visited:
                     queue.append(neighbour)
-                    visited.append(neighbour)
+                    visited.add(neighbour)
 
                     levels[neighbour] = levels[node] + 1
 
@@ -1373,19 +1373,31 @@ def init_graph_transform(graph, embedding):
     new_embedding: array of shape (n_new_samples, dim)
         An initial embedding of the new sample points.
     """
-    result = np.zeros((graph.shape[0], embedding.shape[1]), dtype=np.float32)
+    n_new = graph.shape[0]
+    result = np.zeros((n_new, embedding.shape[1]), dtype=np.float32)
 
-    for row_index in range(graph.shape[0]):
-        graph_row = graph[row_index]
-        if graph_row.nnz == 0:
-            result[row_index] = np.nan
-            continue
-        row_sum = graph_row.sum()
-        for graph_value, col_index in zip(graph_row.data, graph_row.indices):
-            if graph_value == 1:
-                result[row_index, :] = embedding[col_index, :]
-                break
-            result[row_index] += graph_value / row_sum * embedding[col_index]
+    row_nnz = np.diff(graph.indptr)
+    empty_mask = row_nnz == 0
+    result[empty_mask] = np.nan
+
+    has_exact = np.zeros(n_new, dtype=bool)
+    exact_data_mask = graph.data == 1.0
+    if exact_data_mask.any():
+        exact_positions = np.where(exact_data_mask)[0]
+        exact_rows = np.searchsorted(graph.indptr, exact_positions, side="right") - 1
+        _, first_idx = np.unique(exact_rows, return_index=True)
+        unique_rows = exact_rows[first_idx]
+        exact_cols = graph.indices[exact_positions[first_idx]]
+        has_exact[unique_rows] = True
+        result[unique_rows] = embedding[exact_cols]
+
+    avg_mask = ~empty_mask & ~has_exact
+    if np.any(avg_mask):
+        avg_graph = graph[avg_mask]
+        row_sums = np.array(avg_graph.sum(axis=1)).flatten()
+        inv_sums = scipy.sparse.diags(1.0 / row_sums)
+        normalized = inv_sums @ avg_graph
+        result[avg_mask] = (normalized @ embedding).astype(np.float32)
 
     return result
 


### PR DESCRIPTION
## Summary

- **`breadth_first_search`**: Use `set` for `visited` (O(1) membership vs O(n) list scan) and `deque` for `queue` (O(1) `popleft` vs O(n) `list.pop(0)`). Speeds up connected component detection.
- **`init_graph_transform`**: Replace per-row Python loop (`graph[row_index]` creates a new sparse matrix per row) with vectorized sparse operations — `np.diff(indptr)` for empty rows, `searchsorted` for exact-match detection, and a single sparse matmul for weighted averages. Speeds up `transform()` on new data.

## Benchmark

5000 samples, 15 neighbors, min of 5 repeats. Python 3.14 / 3.13 on Apple Silicon.

| Function | Python | Before | After | Speedup |
|---|---|---|---|---|
| `breadth_first_search` | 3.14 | 7.92 ms | 1.05 ms | **7.5x** |
| `breadth_first_search` | 3.13 | 6.91 ms | 1.09 ms | **6.3x** |
| `init_graph_transform` | 3.14 | 115.12 ms | 0.57 ms | **195x** |
| `init_graph_transform` | 3.13 | 113.84 ms | 0.58 ms | **196x** |
| Peak memory | both | 31.04 MB | 31.04 MB | no change |

No regressions on `compute_membership_strengths`, `_densmap_original_densities`, or end-to-end `fit_transform`.

## Test plan

- [x] `test_umap.py` — 10 passed
- [x] `test_umap_trustworthiness.py` — 7 passed
- [x] `test_umap_ops.py` — 12 passed
- [x] `test_densmap.py` — 4 passed (3 skipped)
- [x] `test_umap_on_iris.py` — 12 passed
- [x] `test_umap_nn.py` — 3 passed (5 skipped)