### PR TITLE
Vectorize expand_relations() with dict lookup arrays in AlignedUMAP

### DIFF
--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -30,6 +30,33 @@ def invert_dict(d):
     return {value: key for key, value in d.items()}
 
 
+def relation_lut(d, n_samples):
+    """Materialize a relation dict as a lookup array: lut[key] = value, else -1.
+
+    Keys and values are bounded by n_samples (see expand_relations), so an
+    array of length n_samples covers every entry and turns each dict.get(n, -1)
+    into a C-level gather instead of a Python-level lookup.
+    """
+    lut = np.full(n_samples, -1, dtype=np.int32)
+    if d:
+        keys = np.fromiter(d.keys(), dtype=np.int64, count=len(d))
+        vals = np.fromiter(d.values(), dtype=np.int64, count=len(d))
+        lut[keys] = vals
+    return lut
+
+
+def chain_relation_lut(lut, mapping):
+    """Apply one relation step: mapping[i] -> lut[mapping[i]], propagating -1.
+
+    Mirrors `np.array([d.get(n, -1) for n in mapping])` where negative sentinels
+    (and missing keys) map to -1, but with masked fancy indexing in C.
+    """
+    nxt = np.full(mapping.shape, -1, dtype=np.int32)
+    valid = mapping >= 0
+    nxt[valid] = lut[mapping[valid]]
+    return nxt
+
+
 @numba.njit()
 def procrustes_align(embedding_base, embedding_to_align, anchors):
     subset1 = embedding_base[anchors[0]]
@@ -53,18 +80,19 @@ def expand_relations(relation_dicts, window_size=3):
         -1,
         dtype=np.int32,
     )
-    reverse_relation_dicts = [invert_dict(d) for d in relation_dicts]
+    # Precompute each relation (and its inverse) as a lookup array once, so the
+    # windowed chaining below uses C-level gathers instead of Python dict.get.
+    luts = [relation_lut(d, max_n_samples) for d in relation_dicts]
+    reverse_luts = [relation_lut(invert_dict(d), max_n_samples) for d in relation_dicts]
     for i in range(result.shape[0]):
         for j in range(window_size):
             result_index = (window_size) + (j + 1)
             if i + j + 1 >= len(relation_dicts):
                 result[i, result_index] = np.full(max_n_samples, -1, dtype=np.int32)
             else:
-                mapping = np.arange(max_n_samples)
+                mapping = np.arange(max_n_samples, dtype=np.int32)
                 for k in range(j + 1):
-                    mapping = np.array(
-                        [relation_dicts[i + k].get(n, -1) for n in mapping]
-                    )
+                    mapping = chain_relation_lut(luts[i + k], mapping)
                 result[i, result_index] = mapping
 
         for j in range(0, -window_size, -1):
@@ -72,11 +100,9 @@ def expand_relations(relation_dicts, window_size=3):
             if i + j - 1 < 0:
                 result[i, result_index] = np.full(max_n_samples, -1, dtype=np.int32)
             else:
-                mapping = np.arange(max_n_samples)
+                mapping = np.arange(max_n_samples, dtype=np.int32)
                 for k in range(0, j - 1, -1):
-                    mapping = np.array(
-                        [reverse_relation_dicts[i + k - 1].get(n, -1) for n in mapping]
-                    )
+                    mapping = chain_relation_lut(reverse_luts[i + k - 1], mapping)
                 result[i, result_index] = mapping
 
     return result
@@ -295,7 +321,7 @@ class AlignedUMAP(BaseEstimator):
     def fit(self, X, y=None, **fit_params):
         if "relations" not in fit_params:
             raise ValueError(
-                "Aligned UMAP requires relations between data to be " "specified"
+                "Aligned UMAP requires relations between data to be specified"
             )
 
         self.dict_relations_ = fit_params["relations"]
@@ -446,7 +472,7 @@ class AlignedUMAP(BaseEstimator):
     def update(self, X, y=None, **fit_params):
         if "relations" not in fit_params:
             raise ValueError(
-                "Aligned UMAP requires relations between data to be " "specified"
+                "Aligned UMAP requires relations between data to be specified"
             )
 
         new_dict_relations = fit_params["relations"]

--- a/umap/tests/test_aligned_umap.py
+++ b/umap/tests/test_aligned_umap.py
@@ -1,5 +1,6 @@
 import pytest
 from umap import AlignedUMAP
+from umap.aligned_umap import expand_relations
 from sklearn.metrics import pairwise_distances
 from sklearn.cluster import KMeans
 import numpy as np
@@ -81,3 +82,74 @@ def test_aligned_update_array_error(aligned_iris, aligned_iris_relations):
         small_aligned_model.update(
             data[3:], relations=aligned_iris_relations[2:], n_neighbors=n_neighbors[3:]
         )
+
+
+# ===============================
+# Test expand_relations (characterization / regression)
+# ===============================
+
+# Multi-slice relations with non-identity mappings and missing keys, chosen so
+# that forward/backward window chaining of depth > 1 produces -1 sentinels.
+_EXPAND_RELATIONS_INPUT = [
+    {0: 1, 1: 2, 2: 0, 3: 3},
+    {0: 0, 2: 1, 3: 2},
+    {1: 0, 2: 3},
+]
+
+_EXPAND_RELATIONS_WS3 = np.array(
+    [
+        [
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [1, 2, 0, 3],
+            [-1, 1, 0, 2],
+            [-1, -1, -1, -1],
+        ],
+        [
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [2, 0, 1, 3],
+            [-1, -1, -1, -1],
+            [0, -1, 1, 2],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+        ],
+        [
+            [-1, -1, -1, -1],
+            [2, 1, 3, -1],
+            [0, 2, 3, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+        ],
+        [
+            [1, -1, -1, 3],
+            [2, -1, -1, 3],
+            [1, -1, -1, 2],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+            [-1, -1, -1, -1],
+        ],
+    ],
+    dtype=np.int32,
+)
+
+
+def test_expand_relations_golden_ws3():
+    result = expand_relations(_EXPAND_RELATIONS_INPUT, window_size=3)
+    assert result.dtype == np.int32
+    np.testing.assert_array_equal(result, _EXPAND_RELATIONS_WS3)
+
+
+@pytest.mark.parametrize(
+    "window_size,shape,total",
+    [(1, (4, 3, 4), -9), (2, (4, 5, 4), -19), (3, (4, 7, 4), -45)],
+)
+def test_expand_relations_shape_and_sum(window_size, shape, total):
+    result = expand_relations(_EXPAND_RELATIONS_INPUT, window_size=window_size)
+    assert result.shape == shape
+    assert int(result.sum()) == total


### PR DESCRIPTION
## Summary

`expand_relations()` in `aligned_umap.py` builds the windowed relation tensor for `AlignedUMAP` by chaining relation dicts. The chaining was done with a Python-level list comprehension inside a triple loop:

```python
mapping = np.array([relation_dicts[i + k].get(n, -1) for n in mapping])
```

This materializes a Python list of `max_n_samples` int objects on every chain step and runs the lookups in the interpreter.

This PR precomputes each relation dict (and its inverse) **once** as an `int32` lookup array and replaces the per-step comprehension with masked NumPy fancy indexing:

```python
nxt = np.full(mapping.shape, -1, dtype=np.int32)
valid = mapping >= 0
nxt[valid] = lut[mapping[valid]]   # C-level gather
```

The `valid = mapping >= 0` mask reproduces `dict.get(n, -1)` semantics exactly — negative sentinels and missing keys map to `-1` — while avoiding the negative-index wraparound a raw `lut[mapping]` would cause. Keys and values are already bounded by `max_n_samples`, so an array of that length covers every entry.

Same asymptotic cost `O(T · window_size² · N)`, but the per-element work moves out of the interpreter and no transient Python-int lists are created. `expand_relations()` runs once per `AlignedUMAP.fit()` and `.update()`.

## Benchmarks

Synthetic relations (10% drop rate), measured on a dev machine — treat as relative. Time = `timeit` min of 5 runs; RAM = `tracemalloc` peak. Output asserted byte-identical between old and new at every size.

### Speed

| Input (slices × samples) | Before | After | Speedup |
|---|---|---|---|
| 5 × 1,000 | 3.24 ms | 0.52 ms | **6.2×** (−84%) |
| 8 × 5,000 | 30.46 ms | 3.64 ms | **8.4×** (−88%) |
| 10 × 10,000 | 80.58 ms | 9.00 ms | **9.0×** (−89%) |

### Peak RAM

| Input (slices × samples) | Before | After | Delta |
|---|---|---|---|
| 5 × 1,000 | 369 KB | 260 KB | **−108 KB (−29%)** |
| 8 × 5,000 | 2,502 KB | 1,780 KB | **−722 KB (−29%)** |
| 10 × 10,000 | 6,128 KB | 4,255 KB | **−1,873 KB (−31%)** |

RAM drops despite the persistent lookup arrays because the old code's per-step list comprehension allocated `~N` boxed Python ints (~28 B each) as transient garbage on every chain step; the new code stays in `int32` arrays end to end.

## Tests

Added characterization tests in `test_aligned_umap.py`:
- `test_expand_relations_golden_ws3` — pins the exact output array for `window_size=3` (non-identity mappings, missing keys, `-1` sentinels from depth-> 1 chaining).
- `test_expand_relations_shape_and_sum` — shape/sum across `window_size` 1, 2, 3.

Both pass on the original implementation and unchanged after the refactor. Full `test_aligned_umap.py` suite passes.
