### PR TITLE
Reduce redundant allocations in sparse KNN, AlignedUMAP and ParametricUMAP

### DIFF
--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -389,12 +389,13 @@ class AlignedUMAP(BaseEstimator):
         epochs_per_samples = numba.typed.List.empty_list(numba.types.float64[::1])
 
         for mapper in self.mappers_:
+            graph_coo = mapper.graph_.tocoo()
             indptr_list.append(mapper.graph_.indptr)
             indices_list.append(mapper.graph_.indices)
-            heads.append(mapper.graph_.tocoo().row)
-            tails.append(mapper.graph_.tocoo().col)
+            heads.append(graph_coo.row)
+            tails.append(graph_coo.col)
             epochs_per_samples.append(
-                make_epochs_per_sample(mapper.graph_.tocoo().data, n_epochs)
+                make_epochs_per_sample(graph_coo.data, n_epochs)
             )
 
         rng_state_transform = np.random.RandomState(self.transform_seed)

--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -442,7 +442,9 @@ class ParametricUMAP(UMAP):
                 self._history[key] += history.history[key]
 
         # get the final embedding
-        embedding = self.encoder.predict(X, verbose=self.verbose)
+        embedding = self.encoder.predict(
+            X, batch_size=self.batch_size, verbose=self.verbose
+        )
 
         return embedding, {}
 

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -2537,10 +2537,14 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
             if self.knn_dists is None:
                 self._knn_indices = np.zeros((X.shape[0], self.n_neighbors), dtype=int)
                 self._knn_dists = np.zeros(self._knn_indices.shape, dtype=float)
+                # X is CSR (check_array(accept_sparse="csr")), so slice its backing
+                # arrays directly instead of materializing a temporary matrix per row.
+                X_indptr, X_indices, X_data = X.indptr, X.indices, X.data
                 for row_id in range(X.shape[0]):
                     # Find KNNs row-by-row
-                    row_data = X[row_id].data
-                    row_indices = X[row_id].indices
+                    row_start, row_end = X_indptr[row_id], X_indptr[row_id + 1]
+                    row_data = X_data[row_start:row_end]
+                    row_indices = X_indices[row_start:row_end]
                     if len(row_data) < self._n_neighbors:
                         raise ValueError(
                             "Some rows contain fewer than n_neighbors distances!"
@@ -3082,9 +3086,13 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
                     (X.shape[0], self._n_neighbors), dtype=np.int32, fill_value=-1
                 )
                 dists = np.full_like(indices, dtype=np.float32, fill_value=-1)
+                # X is CSR (check_array(accept_sparse="csr")), so slice its backing
+                # arrays directly instead of materializing a temporary matrix per row.
+                X_indptr, X_indices, X_data = X.indptr, X.indices, X.data
                 for i in range(X.shape[0]):
-                    row_data = X[i].data
-                    row_indices = X[i].indices
+                    row_start, row_end = X_indptr[i], X_indptr[i + 1]
+                    row_data = X_data[row_start:row_end]
+                    row_indices = X_indices[row_start:row_end]
                     if len(row_data) < self._n_neighbors:
                         raise ValueError(
                             f"Need at least n_neighbors ({self.n_neighbors}) distances for each row!"


### PR DESCRIPTION
## What

Three constant-factor optimizations in hot paths. No behavior change — same outputs, fewer allocations.

1. **`umap_.py` — sparse precomputed KNN (fit + transform).** The per-row loop did `X[row].data` and `X[row].indices`, which slices the CSR matrix **twice per row**, each call materializing a temporary `1×N` CSR matrix. Since `check_array(accept_sparse="csr")` guarantees `X` is CSR, we hoist `indptr`/`indices`/`data` once and slice the backing arrays directly by `indptr` range (zero-copy views). CSR integer row-slicing returns exactly that `indptr` slice in the same stored order, so `argpartition`/`argsort` select identical neighbours.
2. **`aligned_umap.py` — `AlignedUMAP.fit_transform`.** `mapper.graph_.tocoo()` was called three times per mapper. Convert once, reuse `.row`/`.col`/`.data`.
3. **`parametric_umap.py` — final embedding.** `encoder.predict(X)` omitted `batch_size`, falling back to the Keras default (32). Pass `batch_size=self.batch_size`, matching `transform()` and `decoder.predict()`. With the default `batch_size=None` this reproduces current behavior exactly.

## Why behavior is preserved

- **#1:** identical neighbour selection — the microbenchmark asserts `np.array_equal` on both `indices` and `dists` between old and new.
- **#2:** same `tocoo()` object, just not recomputed.
- **#3:** prediction is independent of batch size; `self.batch_size=None` (default) → Keras default, i.e. no change.

## Performance

Isolated microbenchmarks of the **changed code pattern** (not end-to-end fit/transform, where these loops are one stage of a larger pipeline, so real-world gains are proportionally smaller). Outputs asserted identical for #1 and #2.

| Change | Metric | Before | After | Delta |
|--------|--------|--------|-------|-------|
| #1 CSR row-slice loop (n=3000, k=40/row) | Time (min) | 63.5 ms | 7.4 ms | **8.6× faster** |
| #1 CSR row-slice loop | Peak RAM | 711 KB | 710 KB | −0.1% (neutral) |
| #2 repeated `tocoo()` (nnz=320k, ×20) | Time (min) | 11.7 ms | 3.9 ms | **3.0× faster** |
| #2 repeated `tocoo()` | Peak RAM | 26.25 MB | 25.00 MB | **−4.8%** |

- Data: synthetic symmetric sparse CSR distance matrix (#1); `scipy.sparse.random` CSR graph (#2).
- 15 reps each, min reported (warmup discarded). Env: NumPy 2.4.6, SciPy 1.17.1, Python 3.14.
- #3 not benchmarked — `ParametricUMAP` needs TensorFlow, not installed in the bench env.

> Numbers from the dev machine; production will vary with hardware, load, and data volume. RAM is neutral on #1 (targets CPU/allocation churn) and down ~4.8% on #2 (fewer transient COO objects).

## Tests

`test_aligned_umap.py` + `test_sparse_precomputed_metric_umap_trustworthiness` + `test_disconnected_data_precomputed` → **11 passed, 1 skipped**. `test_parametric_umap.py` → skipped (no TensorFlow). `ruff check` → no new findings.
