### PR TITLE
Speed up build_neighborhood_similarities by precomputing relation membership

### DIFF
--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -112,6 +112,7 @@ def expand_relations(relation_dicts, window_size=3):
 def build_neighborhood_similarities(graphs_indptr, graphs_indices, relations):
     result = np.zeros(relations.shape, dtype=np.float32)
     center_index = (relations.shape[1] - 1) // 2
+    n_samples = relations.shape[2]
     for i in range(relations.shape[0]):
         base_graph_indptr = graphs_indptr[i]
         base_graph_indices = graphs_indices[i]
@@ -121,16 +122,30 @@ def build_neighborhood_similarities(graphs_indptr, graphs_indices, relations):
 
             comparison_graph_indptr = graphs_indptr[i + j - center_index]
             comparison_graph_indices = graphs_indices[i + j - center_index]
-            for k in range(relations.shape[2]):
-                comparison_index = relations[i, j, k]
+
+            # relations[i, j] is constant across k, so precompute once which
+            # comparison-model indices appear as values in it. This replaces the
+            # per-sample set(relations[i, j]) rebuild inside in1d (an
+            # O(n_samples) cost paid for every k) with an O(degree) membership
+            # lookup. A value >= n_samples can never appear in relations[i, j],
+            # so it maps to False, exactly matching in1d's set-membership result.
+            relation_row = relations[i, j]
+            present = np.zeros(n_samples, dtype=np.bool_)
+            for b in range(n_samples):
+                v = relation_row[b]
+                if v >= 0:
+                    present[v] = True
+
+            for k in range(n_samples):
+                comparison_index = relation_row[k]
                 if comparison_index < 0:
                     continue
 
                 raw_base_graph_indices = base_graph_indices[
                     base_graph_indptr[k] : base_graph_indptr[k + 1]
                 ].copy()
-                base_indices = relations[i, j][
-                    raw_base_graph_indices[raw_base_graph_indices < relations.shape[2]]
+                base_indices = relation_row[
+                    raw_base_graph_indices[raw_base_graph_indices < n_samples]
                 ]
                 base_indices = base_indices[base_indices >= 0]
                 comparison_indices = comparison_graph_indices[
@@ -138,9 +153,14 @@ def build_neighborhood_similarities(graphs_indptr, graphs_indices, relations):
                         comparison_index + 1
                     ]
                 ]
-                comparison_indices = comparison_indices[
-                    in1d(comparison_indices, relations[i, j])
-                ]
+                comparison_mask = np.empty(comparison_indices.shape[0], dtype=np.bool_)
+                for idx in range(comparison_indices.shape[0]):
+                    c = comparison_indices[idx]
+                    if c < n_samples:
+                        comparison_mask[idx] = present[c]
+                    else:
+                        comparison_mask[idx] = False
+                comparison_indices = comparison_indices[comparison_mask]
 
                 intersection_size = intersect1d(base_indices, comparison_indices).shape[
                     0


### PR DESCRIPTION
## What

Optimizes `build_neighborhood_similarities` in `umap/aligned_umap.py` (used by `AlignedUMAP.fit`). **No change to output** — the Jaccard regularisation weights are byte-identical.

The per-sample loop called `in1d(comparison_indices, relations[i, j])`, which rebuilt `set(relations[i, j])` (up to `n_samples` entries) **for every sample `k`**. Since `relations[i, j]` is constant across `k`, this made an `O(n_samples)` membership build into a per-`k` cost — worst case `O(M · W · N · (N + r))`.

Now we precompute, **once per `(i, j)`**, a boolean `present` mask of which comparison-model indices appear as values in `relations[i, j]`, and test comparison neighbours against it — `O(M · W · N · r)`.

## Why output is preserved

- `present[c]` reproduces `in1d`'s set membership exactly: a value `>= n_samples` can never be a relation value, so it maps to `False` (matching `set(relations[i, j])` membership for any `c >= 0`).
- `intersect1d` / `union1d` are **left untouched**, so the Jaccard numerator/denominator — including their duplicate-sensitive and empty-array edge handling — are identical.

Verified byte-for-byte (`max|diff| = 0`) against the original on **real captured `AlignedUMAP(iris)` inputs** and on synthetic inputs across sizes.

## Performance (isolated kernel, A/B on identical inputs)

Output asserted identical for every row below.

| Input (M models × N samples, k≈deg) | Time before → after | Speedup |
|---|---|---|
| M=5, N=50, k=12 | 149.5 ms → 0.97 ms | **153×** |
| M=6, N=400, k=15 | 2724.7 ms → 11.0 ms | **249×** |
| M=6, N=1000, k=15 | 7382.5 ms → 26.9 ms | **274×** |

Speedup grows with N, confirming the removed `O(N)` factor. (The original also called `in1d`, a `@njit(parallel=True)` function, once per sample — paying parallel-region launch overhead on top of the set rebuild.)

## Memory (not higher — lower)

Numba allocations are C-level (invisible to `tracemalloc`), so measured via NRT allocation stats (`NUMBA_NRT_STATS=1`):

| N | NRT allocations before → after | Largest transient structure before → after |
|---|---|---|
| 400 | 258,581 → 239,451 (**−7.4%**) | `set(400 int64)` ≥3200 B → `bool[400]` 400 B (**8× smaller**) |
| 1000 | 647,165 → 599,251 (**−7.4%**) | `set(1000 int64)` ≥8000 B → `bool[1000]` 1000 B (**8× smaller**) |

`net-live = 0` (allocs − frees) for both → all transients freed, no leak. The `present` mask is one `bool[n_samples]` per `(i, j)`, replacing a `set` of up to `n_samples` int64 rebuilt per `k`: smaller per element and amortized over N samples, so peak transient memory only goes down.

## Tests

`umap/tests/test_aligned_umap.py` → 8 passed, 1 skipped. `ruff check umap/aligned_umap.py` → clean.

> Benchmarks ran on the dev machine (NumPy 2.4.6, Numba 0.65.1, Python 3.14); absolute numbers vary with hardware and data, but the asymptotic improvement and identical output do not.
