### PR TITLE
Add docstring to ParametricUMAP placeholder class for better documentation

### DIFF
--- a/umap/__init__.py
+++ b/umap/__init__.py
@@ -13,6 +13,23 @@ except ImportError:
 
     # Add a dummy class to raise an error
     class ParametricUMAP(object):
+        """A placeholder class for ParametricUMAP when TensorFlow is not installed.
+
+        This class provides a graceful error message when users attempt to instantiate
+        ParametricUMAP without having TensorFlow installed. The real implementation
+        requires TensorFlow >= 2.0 and is loaded from umap.parametric_umap.
+
+        Examples
+        --------
+        >>> try:
+        ...     from umap import ParametricUMAP
+        ... except ImportError:
+        ...     pass  # TensorFlow not available
+
+        See Also
+        --------
+        load_ParametricUMAP : Load a saved ParametricUMAP model
+        """
         def __init__(self, **kwds):
             warn(
                 """The umap.parametric_umap package requires Tensorflow > 2.0 to be installed.


### PR DESCRIPTION
## Problem
The `ParametricUMAP` class in `umap/__init__.py`, which serves as a placeholder when TensorFlow is not installed, was missing a docstring. This reduced code readability and made it harder for users to understand its purpose and error handling.

## Solution
Added a comprehensive docstring to the `ParametricUMAP` class. The docstring includes:
- A clear description of the class's role as a placeholder when TensorFlow is unavailable.
- Usage examples to help users handle import scenarios gracefully.
- References to related functions (e.g., `load_ParametricUMAP`) for better discoverability.

## Verification
- Review the updated `__init__.py` file to confirm the docstring is present and correctly formatted.
- Run existing tests to ensure no functional changes or regressions (e.g., `python -m pytest` in the repository).
- Check that the class's behavior remains unchanged: it should still warn and raise an `ImportError` when instantiated without TensorFlow.