### PR TITLE
Fix NaN gradients in parametric UMAP loss under XLA (#1200, #1211)

### DIFF
--- a/umap/aligned_umap.py
+++ b/umap/aligned_umap.py
@@ -414,9 +414,7 @@ class AlignedUMAP(BaseEstimator):
             indices_list.append(mapper.graph_.indices)
             heads.append(graph_coo.row)
             tails.append(graph_coo.col)
-            epochs_per_samples.append(
-                make_epochs_per_sample(graph_coo.data, n_epochs)
-            )
+            epochs_per_samples.append(make_epochs_per_sample(graph_coo.data, n_epochs))
 
         rng_state_transform = np.random.RandomState(self.transform_seed)
         regularisation_weights = build_neighborhood_similarities(

--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -12,14 +12,16 @@ try:
     # Used for tf.data.
     import tensorflow as tf
 except ImportError:
-    warn("""The umap.parametric_umap package requires Tensorflow > 2.0 to be installed.
+    warn(
+        """The umap.parametric_umap package requires Tensorflow > 2.0 to be installed.
     You can install Tensorflow at https://www.tensorflow.org/install
     
     or you can install the CPU version of Tensorflow using 
 
     pip install umap-learn[parametric_umap]
 
-    """)
+    """
+    )
     raise ImportError("umap.parametric_umap requires Tensorflow >= 2.0") from None
 
 try:
@@ -179,8 +181,7 @@ class ParametricUMAP(UMAP):
             nan_array = np.empty(self.n_components)
             nan_array.fill(np.nan)
             landmark_positions = np.stack(
-                [nan_array] * X.shape[0]
-                + list(self.transform(self.prev_epoch_X))
+                [nan_array] * X.shape[0] + list(self.transform(self.prev_epoch_X))
             )
             X = np.concatenate((X, self.prev_epoch_X))
 
@@ -188,13 +189,17 @@ class ParametricUMAP(UMAP):
             len_X = len(X)
             len_land = len(landmark_positions)
             if len_X != len_land:
-                raise ValueError(f"Length of x = {len_X}, length of landmark_positions \
-                    = {len_land}, while it must be equal.")
+                raise ValueError(
+                    f"Length of x = {len_X}, length of landmark_positions \
+                    = {len_land}, while it must be equal."
+                )
 
         if self.metric == "precomputed":
             if precomputed_distances is None:
-                raise ValueError("Precomputed distances must be supplied if metric \
-                    is precomputed.")
+                raise ValueError(
+                    "Precomputed distances must be supplied if metric \
+                    is precomputed."
+                )
             # prepare X for training the network
             self._X = X
             # geneate the graph on precomputed distances
@@ -240,8 +245,7 @@ class ParametricUMAP(UMAP):
             nan_array = np.empty(self.n_components)
             nan_array.fill(np.nan)
             landmark_positions = np.stack(
-                [nan_array] * X.shape[0]
-                + list(self.transform(self.prev_epoch_X))
+                [nan_array] * X.shape[0] + list(self.transform(self.prev_epoch_X))
             )
             X = np.concatenate((X, self.prev_epoch_X))
 
@@ -249,13 +253,17 @@ class ParametricUMAP(UMAP):
             len_X = len(X)
             len_land = len(landmark_positions)
             if len_X != len_land:
-                raise ValueError(f"Length of x = {len_X}, length of landmark_positions \
-                    = {len_land}, while it must be equal.")
+                raise ValueError(
+                    f"Length of x = {len_X}, length of landmark_positions \
+                    = {len_land}, while it must be equal."
+                )
 
         if self.metric == "precomputed":
             if precomputed_distances is None:
-                raise ValueError("Precomputed distances must be supplied if metric \
-                    is precomputed.")
+                raise ValueError(
+                    "Precomputed distances must be supplied if metric \
+                    is precomputed."
+                )
             # prepare X for training the network
             self._X = X
             # generate the graph on precomputed distances
@@ -701,9 +709,9 @@ def init_embedding_from_graph(
 
 
 def _distance(x, y):
-    # The epsilon keeps the gradient finite where x == y. 
+    # The epsilon keeps the gradient finite where x == y.
     # A bare norm has a 0/0 gradient at zero distance.
-    # Keras 3 enables XLA by default when GPU is present, 
+    # Keras 3 enables XLA by default when GPU is present,
     # and XLA returns 0/0 gradient as NaN rather than 0.
     return ops.sqrt(ops.sum((x - y) ** 2, axis=1) + 1e-12)
 

--- a/umap/parametric_umap.py
+++ b/umap/parametric_umap.py
@@ -700,6 +700,14 @@ def init_embedding_from_graph(
     return embedding
 
 
+def _distance(x, y):
+    # The epsilon keeps the gradient finite where x == y. 
+    # A bare norm has a 0/0 gradient at zero distance.
+    # Keras 3 enables XLA by default when GPU is present, 
+    # and XLA returns 0/0 gradient as NaN rather than 0.
+    return ops.sqrt(ops.sum((x - y) ** 2, axis=1) + 1e-12)
+
+
 def convert_distance_to_log_probability(distances, a=1.0, b=1.0):
     """
      convert distance representation into log probability,
@@ -1102,12 +1110,8 @@ class StopGradient(keras.layers.Layer):
 
 
 def _default_landmark_loss(y, y_pred):
-    # Euclidean distance between points.
-    # Use sqrt(sum_sq + eps) instead of norm to avoid NaN gradient at zero.
     # Relu activation smooths gradients.
-    sq_diff = ops.sum((y_pred - y) ** 2, axis=1)
-    safe_dist = ops.sqrt(sq_diff + 1e-10)
-    return keras.activations.relu(ops.mean(safe_dist))
+    return keras.activations.relu(ops.mean(_distance(y_pred, y)))
 
 
 class UMAPModel(keras.Model):
@@ -1225,8 +1229,8 @@ class UMAPModel(keras.Model):
         #  distances between samples (and negative samples)
         distance_embedding = ops.concatenate(
             [
-                ops.norm(embedding_to - embedding_from, axis=1),
-                ops.norm(embedding_neg_to - embedding_neg_from, axis=1),
+                _distance(embedding_to, embedding_from),
+                _distance(embedding_neg_to, embedding_neg_from),
             ],
             axis=0,
         )
@@ -1271,8 +1275,8 @@ class UMAPModel(keras.Model):
         x = ops.clip(x, -10, 10)
         z_x = ops.clip(z_x, -10, 10)
 
-        dx = ops.norm(x[1:] - x[:-1], axis=1)
-        dz = ops.norm(z_x[1:] - z_x[:-1], axis=1)
+        dx = _distance(x[1:], x[:-1])
+        dz = _distance(z_x[1:], z_x[:-1])
 
         # jitter dz to prevent mode collapse
         dz = dz + keras.random.uniform(dz.shape, seed=self.seed_generator) * 1e-10

--- a/umap/plot.py
+++ b/umap/plot.py
@@ -949,6 +949,7 @@ def connectivity(
 
     return ax
 
+
 def diagnostic(
     umap_object,
     diagnostic_type="pca",
@@ -961,7 +962,7 @@ def diagnostic(
     width=800,
     height=800,
     return_diagnostics=False,
-    plot_result=True
+    plot_result=True,
 ):
     """Provide a diagnostic plot or plots for a UMAP embedding, with options to return diagnostics and control plotting.
     There are a number of plots that can be helpful for diagnostic
@@ -1066,7 +1067,7 @@ def diagnostic(
         dpi = plt.rcParams["figure.dpi"]
         if diagnostic_type in ("local_dim", "neighborhood"):
             width *= 1.1
-        fig = plt.figure(figsize=(width/dpi, height/dpi))
+        fig = plt.figure(figsize=(width / dpi, height / dpi))
         ax = fig.add_subplot(111)
 
     font_color = _select_font_color(background) if plot_result else None
@@ -1082,7 +1083,9 @@ def diagnostic(
         diagnostic_data = color_proj
 
         if plot_result:
-            ax.scatter(points[:, 0], points[:, 1], s=point_size, c=color_proj, alpha=0.66)
+            ax.scatter(
+                points[:, 0], points[:, 1], s=point_size, c=color_proj, alpha=0.66
+            )
             ax.set_title("Colored by RGB coords of PCA embedding")
             ax.text(
                 0.99,
@@ -1105,7 +1108,9 @@ def diagnostic(
         diagnostic_data = color_proj
 
         if plot_result:
-            ax.scatter(points[:, 0], points[:, 1], s=point_size, c=color_proj, alpha=0.66)
+            ax.scatter(
+                points[:, 0], points[:, 1], s=point_size, c=color_proj, alpha=0.66
+            )
             ax.set_title("Colored by RGB coords of FastICA embedding")
             ax.text(
                 0.99,
@@ -1131,7 +1136,9 @@ def diagnostic(
         diagnostic_data = color_proj
 
         if plot_result:
-            ax.scatter(points[:, 0], points[:, 1], s=point_size, c=color_proj, alpha=0.66)
+            ax.scatter(
+                points[:, 0], points[:, 1], s=point_size, c=color_proj, alpha=0.66
+            )
             ax.set_title("Colored by RGB coords of Vector Quantization")
             ax.text(
                 0.99,
@@ -1230,9 +1237,11 @@ def diagnostic(
         if plot_result:
             cols = int(len(_diagnostic_types) ** 0.5 // 1)
             rows = len(_diagnostic_types) // cols + 1
-            fig, axs = plt.subplots(rows, cols, figsize=(10, 10), constrained_layout=True)
+            fig, axs = plt.subplots(
+                rows, cols, figsize=(10, 10), constrained_layout=True
+            )
             axs = axs.flat
-            for ax in axs[len(_diagnostic_types):]:
+            for ax in axs[len(_diagnostic_types) :]:
                 ax.remove()
             diagnostic_data = {}
             for ax, plt_type in zip(axs, _diagnostic_types):
@@ -1242,7 +1251,7 @@ def diagnostic(
                     ax=ax,
                     point_size=point_size / 4.0,
                     return_diagnostics=True,
-                    plot_result=True
+                    plot_result=True,
                 )
                 diagnostic_data[plt_type] = sub_diagnostic
         else:
@@ -1253,7 +1262,7 @@ def diagnostic(
                     diagnostic_type=plt_type,
                     point_size=point_size / 4.0,
                     return_diagnostics=True,
-                    plot_result=False
+                    plot_result=False,
                 )
                 diagnostic_data[plt_type] = sub_diagnostic
 
@@ -1270,6 +1279,7 @@ def diagnostic(
         return diagnostic_data
     else:
         return ax
+
 
 def interactive(
     umap_object,

--- a/umap/tests/test_parametric_umap.py
+++ b/umap/tests/test_parametric_umap.py
@@ -158,3 +158,33 @@ def test_landmark_retraining_no_nan():
     p.fit(x2)
     assert not np.any(np.isnan(p._history["loss"][-5:]))
     assert p.parametric_model.landmark_loss_weight == 0.01
+
+
+@tf_only
+def test_umap_loss_grads_finite_under_xla():
+    """UMAP loss must not give NaN gradients when two embeddings coincide.
+
+    jit_compile is forced on so that CPU-only CI exercises the GPU path: Keras
+    resolves jit_compile="auto" to True whenever a GPU is visible.
+    """
+    from umap.parametric_umap import UMAPModel, prepare_networks
+
+    batch_size, dims = 128, 16
+    encoder, decoder = prepare_networks(None, None, 2, [dims], batch_size, False)
+    model = UMAPModel(1.577, 0.895, 5, encoder, decoder)
+
+    to_x = np.random.RandomState(42).rand(batch_size, dims).astype(np.float32)
+    # roll rather than randomise, so coincident pairs are guaranteed every run
+    from_x = np.roll(to_x, batch_size // 2, axis=0)
+
+    @tf.function(jit_compile=True)
+    def grads():
+        with tf.GradientTape() as tape:
+            loss = model._umap_loss(model((to_x, from_x)))
+        return tape.gradient(loss, model.trainable_variables)
+
+    # the loss value stays finite while the gradients are already NaN, so this
+    # has to assert on the gradients
+    for g in grads():
+        assert g is not None
+        assert not np.any(np.isnan(np.asarray(g))), "NaN gradient under XLA"

--- a/umap/tests/test_umap_get_feature_names_out.py
+++ b/umap/tests/test_umap_get_feature_names_out.py
@@ -52,7 +52,6 @@ def test_get_feature_names_out_multicomponent():
     np.testing.assert_array_equal(result_umap, expected_umap_result)
 
 
-
 def test_get_feature_names_out_featureunion():
     X, _ = make_classification(n_samples=30, n_features=10, random_state=42)
     pipeline = Pipeline(

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -1214,9 +1214,14 @@ def simplicial_set_embedding(
         ro = np.zeros(n_vertices, dtype=np.float32)
         dists_csr = dists.tocsr()
         _densmap_original_densities(
-            head, tail, graph.data,
-            dists_csr.indptr, dists_csr.indices, dists_csr.data,
-            ro, mu_sum,
+            head,
+            tail,
+            graph.data,
+            dists_csr.indptr,
+            dists_csr.indices,
+            dists_csr.data,
+            ro,
+            mu_sum,
         )
 
         epsilon = 1e-8
@@ -1329,9 +1334,14 @@ def simplicial_set_embedding(
         tail = emb_graph.col
         emb_dists_csr = emb_dists.tocsr()
         _densmap_embedding_densities(
-            head, tail, emb_graph.data,
-            emb_dists_csr.indptr, emb_dists_csr.indices, emb_dists_csr.data,
-            re, mu_sum,
+            head,
+            tail,
+            emb_graph.data,
+            emb_dists_csr.indptr,
+            emb_dists_csr.indices,
+            emb_dists_csr.data,
+            re,
+            mu_sum,
         )
 
         epsilon = 1e-8
@@ -2569,8 +2579,12 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
                             "Some rows contain fewer than n_neighbors distances!"
                         )
                     # argpartition selects the k smallest in O(d) vs O(d·log d) for argsort
-                    row_nn_data_indices = np.argpartition(row_data, self._n_neighbors)[: self._n_neighbors]
-                    row_nn_data_indices = row_nn_data_indices[np.argsort(row_data[row_nn_data_indices])]
+                    row_nn_data_indices = np.argpartition(row_data, self._n_neighbors)[
+                        : self._n_neighbors
+                    ]
+                    row_nn_data_indices = row_nn_data_indices[
+                        np.argsort(row_data[row_nn_data_indices])
+                    ]
                     self._knn_indices[row_id] = row_indices[row_nn_data_indices]
                     self._knn_dists[row_id] = row_data[row_nn_data_indices]
             else:
@@ -3126,15 +3140,23 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
                         raise ValueError(
                             f"Need at least n_neighbors ({self.n_neighbors}) distances for each row!"
                         )
-                    row_nn_data_indices = np.argpartition(row_data, self._n_neighbors)[: self._n_neighbors]
-                    row_nn_data_indices = row_nn_data_indices[np.argsort(row_data[row_nn_data_indices])]
+                    row_nn_data_indices = np.argpartition(row_data, self._n_neighbors)[
+                        : self._n_neighbors
+                    ]
+                    row_nn_data_indices = row_nn_data_indices[
+                        np.argsort(row_data[row_nn_data_indices])
+                    ]
                     indices[i] = row_indices[row_nn_data_indices]
                     dists[i] = row_data[row_nn_data_indices]
             else:
-                indices = np.argpartition(X, self._n_neighbors, axis=1)[:, : self._n_neighbors]
+                indices = np.argpartition(X, self._n_neighbors, axis=1)[
+                    :, : self._n_neighbors
+                ]
                 dists = np.take_along_axis(X, indices, axis=1)
                 sorted_idx = np.argsort(dists, axis=1)
-                indices = np.take_along_axis(indices, sorted_idx, axis=1).astype(np.int32)
+                indices = np.take_along_axis(indices, sorted_idx, axis=1).astype(
+                    np.int32
+                )
                 dists = np.take_along_axis(dists, sorted_idx, axis=1)
             assert np.min(indices) >= 0 and np.min(dists) >= 0.0
         elif self._small_data:


### PR DESCRIPTION
Hi team,

I've Implemented what I believe are fixes for #1200 and #1211, closing off all remaining issues with ParametricUMAP NaN loss.

The issue seems to have been introduced with Keras 3, which enables XLA whenever GPU is available. When using XLA, ops.norm takes 0/0 gradient and returns NaN. This explains why the error was intermittent across hardware and data, as 0/0 gradient appears when data contains duplicate rows OR when duplicate entries are negatively sampled by ParametricUMAP. This error gives NaN gradient within a few steps, thus the confusion with potential exploding gradients, etc.

This bug occurs in all versions since 0.5.0; reachable since the Keras 3 port in 0.5.6. It is a different error to the NaN loss fixed by #1244 (which was itself caused by 3 seperate issues...).

To fix, I have replaced ops.norm with a _distance() helper in _umap_loss and _global_correlation_loss, as well as in the landmarks loss which is now a bit cleaner as a result. PR includes a test, which forces jit_compile=True so the CI pipeline can catch it despite running on CPU.

I've also run black, which has picked up some bits and pieces across other files, but have kept my functional changes isolated to the first commit of two in the PR.

Happy to chat about anything I've missed/not considered. If possible, a new release including these fixes would be much appreciated for various use cases.