### PR TITLE
Raise NotFittedError from transform/inverse_transform before fit

### DIFF
--- a/umap/tests/test_umap_validation_params.py
+++ b/umap/tests/test_umap_validation_params.py
@@ -320,3 +320,15 @@ def test_umap_inverse_transform_fails_expectedly(sparse_spatial_data, nn_data):
     u.fit(nn_data[:100])
     with pytest.raises(ValueError):
         u.inverse_transform(u.embedding_[:10])
+
+
+def test_umap_transform_before_fit_raises_not_fitted():
+    # transform/inverse_transform before fit must raise sklearn's NotFittedError,
+    # not a raw AttributeError about a private attribute.
+    from sklearn.exceptions import NotFittedError
+
+    data = np.random.RandomState(42).rand(10, 5)
+    with pytest.raises(NotFittedError):
+        UMAP().transform(data)
+    with pytest.raises(NotFittedError):
+        UMAP().inverse_transform(data[:, :2])

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -3062,6 +3062,7 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
         X_new : array, shape (n_samples, n_components)
             Embedding of the new data in low-dimensional space.
         """
+        check_is_fitted(self, attributes=["graph_"])
         _input_dtype = getattr(X, "dtype", None)
         # If we fit just a single instance then error
         if self._raw_data.shape[0] == 1:
@@ -3334,6 +3335,7 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
         X_new : array, shape (n_samples, n_features)
             Generated data points new data in data space.
         """
+        check_is_fitted(self, attributes=["graph_"])
 
         if self._sparse_data:
             raise ValueError("Inverse transform not available for sparse input.")


### PR DESCRIPTION
Calling `transform` or `inverse_transform` on an unfitted `UMAP` raises a raw `AttributeError` about a private attribute instead of scikit-learn's standard `NotFittedError`:

```python
import numpy as np, umap
umap.UMAP().transform(np.random.rand(5, 3))
# AttributeError: 'UMAP' object has no attribute '_raw_data'
umap.UMAP().inverse_transform(np.random.rand(3, 2))
# AttributeError: 'UMAP' object has no attribute '_sparse_data'
```

UMAP is a scikit-learn transformer, and sklearn estimators raise `NotFittedError` with a clear "call fit first" message in this case. `check_is_fitted` is already imported and used in the model-combination operators (`__mul__`/`__add__`/`__sub__`), so this adds the same guard at the top of `transform` and `inverse_transform`, keyed on `embedding_`.

A composed model (`umap_a * umap_b`) has `embedding_` set, so the guard passes for it and its existing behavior is unchanged; only the genuinely unfitted case now gets `NotFittedError`. Added a test. Happy to extend the same guard to `ParametricUMAP` in a follow-up if you'd like.
