### PR TITLE
Fix smooth_knn_dist giving sigma = inf for points with a disconnected neighbour

### DIFF
--- a/umap/tests/test_umap_nn.py
+++ b/umap/tests/test_umap_nn.py
@@ -166,3 +166,33 @@ def test_smooth_knn_dist_l1norms_w_connectivity(nn_data):
         err_msg="Smooth knn-dists does not give expected"
         "norms for local_connectivity=1.75",
     )
+
+
+def test_smooth_knn_dist_disconnected_neighbors():
+    """Neighbours pruned by disconnection_distance carry an inf distance. They
+    must not enter the MIN_K_DIST_SCALE floor (np.mean of a row with inf is
+    inf), which previously made sigma inf and every remaining edge of such a
+    point a membership strength of exactly 1.0."""
+    rng = np.random.RandomState(0)
+    k = 10
+    dists = np.sort(rng.uniform(0.5, 2.0, size=(20, k)), axis=1).astype(np.float32)
+    dists[:, 0] = 0.0  # self
+    dists[:10, 7:] = np.inf  # three pruned neighbours in the first ten rows
+    sigmas, rhos = smooth_knn_dist(dists, float(k))
+    assert np.all(np.isfinite(sigmas)), "sigma is inf for rows with pruned neighbours"
+    # rho is still the distance to the nearest (finite) neighbour
+    assert_array_almost_equal(rhos, dists[:, 1])
+    # the kernel over the finite non-self neighbours still sums to log2(k)
+    shifted = dists[:, 1:] - rhos[:, np.newaxis]
+    shifted[shifted < 0.0] = 0.0
+    vals = np.exp(-(shifted / sigmas[:, np.newaxis]))
+    vals[~np.isfinite(dists[:, 1:])] = 0.0
+    assert_array_almost_equal(
+        np.sum(vals, axis=1),
+        np.log2(k) * np.ones(dists.shape[0]),
+        decimal=3,
+        err_msg="Smooth knn-dists does not give expected norms with pruned neighbours",
+    )
+    # and the finite rows are untouched by the change
+    sigmas_finite, rhos_finite = smooth_knn_dist(dists[10:], float(k))
+    assert_array_almost_equal(sigmas[10:], sigmas_finite, decimal=5)

--- a/umap/tests/test_umap_ops.py
+++ b/umap/tests/test_umap_ops.py
@@ -170,6 +170,33 @@ def test_disconnected_data(num_isolates, metric, force_approximation):
         assert number_of_nan >= num_isolates * model.n_components
 
 
+def test_disconnection_distance_keeps_sigma_finite():
+    """A point whose k-nn list mixes kept and pruned neighbours must keep a finite
+    sigma, so that its remaining edges are weighted by the usual kernel rather
+    than all set to 1.0 (the pruned neighbours used to make the row mean, and
+    hence the sigma floor, infinite)."""
+    rng = np.random.RandomState(0)
+    small = rng.normal(0, 0.3, (8, 5)).astype(np.float32)
+    big = (rng.normal(0, 1.0, (300, 5)) + 10.0).astype(np.float32)
+    data = np.vstack([small, big])
+    for force_approximation in (False, True):
+        model = UMAP(
+            n_neighbors=15,
+            disconnection_distance=5.0,
+            random_state=42,
+            force_approximation_algorithm=force_approximation,
+        ).fit(data)
+        assert np.all(np.isfinite(model._sigmas))
+        rows = model.graph_.tocsr()[:8].toarray()
+        # each small-cluster point keeps its 7 in-cluster edges; the nearest
+        # neighbour (and reciprocal nearest neighbours) have strength 1, the
+        # others are strictly weaker instead of all being 1.0
+        assert np.all((rows > 0.0).sum(axis=1) == 7)
+        assert np.all(rows[rows > 0.0] <= 1.0)
+        assert np.all((rows == 1.0).sum(axis=1) < (rows > 0.0).sum(axis=1))
+        assert np.all([row[row > 0.0].min() < 0.9 for row in rows])
+
+
 @pytest.mark.parametrize("num_isolates", [1])
 @pytest.mark.parametrize("sparse", [True, False])
 def test_disconnected_data_precomputed(num_isolates, sparse):

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -193,7 +193,17 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
     rho = np.zeros(distances.shape[0], dtype=np.float32)
     result = np.zeros(distances.shape[0], dtype=np.float32)
 
-    mean_distances = np.mean(distances)
+    # Neighbours pruned by disconnection_distance (or inf entries of a
+    # precomputed distance matrix) arrive here as inf. They must be excluded
+    # from rho and from the MIN_K_DIST_SCALE floor: the mean of a row that
+    # contains inf is inf, which made sigma inf for every point with a pruned
+    # neighbour and gave all of its remaining edges membership strength 1.0.
+    flat_distances = distances.ravel()
+    finite_distances = flat_distances[np.isfinite(flat_distances)]
+    if finite_distances.shape[0] > 0:
+        mean_distances = np.mean(finite_distances)
+    else:
+        mean_distances = 0.0
 
     for i in numba.prange(distances.shape[0]):
         lo = 0.0
@@ -202,7 +212,8 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
 
         # TODO: This is very inefficient, but will do for now. FIXME
         ith_distances = distances[i]
-        non_zero_dists = ith_distances[ith_distances > 0.0]
+        finite_ith_distances = ith_distances[np.isfinite(ith_distances)]
+        non_zero_dists = finite_ith_distances[finite_ith_distances > 0.0]
         if non_zero_dists.shape[0] >= local_connectivity:
             index = int(np.floor(local_connectivity))
             interpolation = local_connectivity - index
@@ -244,7 +255,7 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0, bandwidth=1
 
         # TODO: This is very inefficient, but will do for now. FIXME
         if rho[i] > 0.0:
-            mean_ith_distances = np.mean(ith_distances)
+            mean_ith_distances = np.mean(finite_ith_distances)
             if result[i] < MIN_K_DIST_SCALE * mean_ith_distances:
                 result[i] = MIN_K_DIST_SCALE * mean_ith_distances
         else:


### PR DESCRIPTION
Fixes #1286.

Neighbours pruned by `disconnection_distance` (and `inf` entries of a precomputed distance
matrix) reach `smooth_knn_dist` as `knn_dists = inf`. The `MIN_K_DIST_SCALE` floor was
computed from `np.mean(ith_distances)`, which is `inf` for such rows, so the floor replaced
the searched sigma with `inf` and `compute_membership_strengths` gave every remaining edge of
the point a membership strength of exactly 1.0. The global `mean_distances` was `inf` as well
as soon as any row contained an `inf`, which did the same to every row with `rho == 0`.

This excludes non-finite distances from `rho` and from both means. Rows without a pruned
neighbour are unchanged (bit-identical sigma on the audit's test data).

Tests:
- `test_umap_nn.py::test_smooth_knn_dist_disconnected_neighbors`: a row with three `inf`
  entries keeps a finite sigma, rho is still the nearest finite neighbour, and the kernel
  over the finite neighbours sums to log2(k); rows without `inf` are unchanged.
- `test_umap_ops.py::test_disconnection_distance_keeps_sigma_finite`: an 8-point cluster
  next to a 300-point cluster with `disconnection_distance=5.0`, on the exact and the
  pynndescent path: finite `_sigmas`, each cluster point keeps its 7 in-cluster edges with
  graded strengths rather than all 1.0.

Both new tests fail on unmodified master (2 failed) and pass with this change;
`umap/tests/test_umap_nn.py` + `umap/tests/test_umap_ops.py`: 25 passed / 7 skipped before,
27 passed / 7 skipped after. `black --check` passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaHntBDKuZJpMAAMenkC44

---
_Generated by [Claude Code](https://claude.ai/code)_