### PR TITLE
Fix transform() refusing precomputed distances when fit used the NN-descent path

### DIFF
--- a/umap/tests/test_umap_on_iris.py
+++ b/umap/tests/test_umap_on_iris.py
@@ -171,6 +171,35 @@ def test_precomputed_transform_on_iris(iris, iris_selection):
     ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
 
 
+# UMAP precomputed metric transform on iris via the NN-descent code path
+# (#1194: with >= 4096 training rows, or force_approximation_algorithm=True,
+# fit() stores _knn_search_index = None for a precomputed metric and transform()
+# used to refuse to run even though the precomputed branch needs no index)
+# ----------------------
+def test_precomputed_transform_on_iris_force_approx(iris, iris_selection):
+    data = iris.data[iris_selection]
+    distance_matrix = squareform(pdist(data))
+
+    fitter = UMAP(
+        n_neighbors=10,
+        min_dist=0.01,
+        random_state=42,
+        n_epochs=100,
+        metric="precomputed",
+        force_approximation_algorithm=True,
+    ).fit(distance_matrix)
+    assert fitter._knn_search_index is None
+
+    new_data = iris.data[~iris_selection]
+    new_distance_matrix = cdist(new_data, data)
+    embedding = fitter.transform(new_distance_matrix)
+
+    trust = trustworthiness(new_data, embedding, n_neighbors=10)
+    assert (
+        trust >= 0.85
+    ), "Insufficiently trustworthy transform for" "iris dataset: {}".format(trust)
+
+
 # UMAP precomputed metric transform on iris with sparse distances
 # ----------------------
 def test_precomputed_sparse_transform_on_iris(iris, iris_selection):

--- a/umap/umap_.py
+++ b/umap/umap_.py
@@ -3104,8 +3104,15 @@ class UMAP(BaseEstimator, ClassNamePrefixFeaturesOutMixin):
             )
 
         # #848: knn_search_index is allowed to be None if not transforming new data,
-        # so now we must validate that if it exists it is not None
-        if hasattr(self, "_knn_search_index") and self._knn_search_index is None:
+        # so now we must validate that if it exists it is not None.
+        # #1194: a precomputed metric never has a search index (nearest_neighbors
+        # returns None for it), and the precomputed branch below does not need
+        # one, so only enforce this for the metrics that query the index.
+        if (
+            self.metric != "precomputed"
+            and hasattr(self, "_knn_search_index")
+            and self._knn_search_index is None
+        ):
             raise NotImplementedError(
                 "No search index available: transforming data"
                 " into an existing embedding is not supported"


### PR DESCRIPTION
Fixes #1194.

**Cause.** For `metric="precomputed"`, `nearest_neighbors()` returns `knn_search_index=None` (`umap/umap_.py`, the `if metric == "precomputed"` branch), and `fit()` stores that as `self._knn_search_index` whenever the training data is not "small" (>= 4096 rows, or `force_approximation_algorithm=True`). `transform()` then hits the #848 guard

```python
if hasattr(self, "_knn_search_index") and self._knn_search_index is None:
    raise NotImplementedError("No search index available: ...")
```

before it reaches its own `if self.metric == "precomputed":` branch, which reads the new-to-training distance matrix and never needs an index. Below 4096 rows `_knn_search_index` is never set, so the same call works; that is the 4095/4096 cliff in #1194.

**Fix.** Skip the guard when `self.metric == "precomputed"` (the only change to `umap_.py`, a condition and a comment). The precomputed path in `transform()` is otherwise untouched, and the #848 behaviour for `precomputed_knn` without an index is unchanged (`test_precomputed_knn_on_iris` still expects the `NotImplementedError`).

**Test.** `test_precomputed_transform_on_iris_force_approx` in `umap/tests/test_umap_on_iris.py`: the existing `test_precomputed_transform_on_iris` with `force_approximation_algorithm=True`, which puts iris down the same code path as a >= 4096-row training set. It raised `NotImplementedError` before this change and passes after.

**Run.** `pytest umap/tests/test_umap_on_iris.py`: 12 passed on master, 13 passed with this change. `black --check umap/umap_.py umap/tests/test_umap_on_iris.py`: unchanged. Minimal reproduction (a 4095-row and a 4096-row synthetic precomputed fit, then `transform` of a 5 x n distance matrix): `NotImplementedError` at 4096 before, both succeed after.

Found while working through open issues in Mytochondria, a volunteer project that verifies fixes for the software behind published results (methods and harnesses: https://github.com/cindykrafft/mytochondria/tree/main/audits/umap)

---
_Generated by [Claude Code](https://claude.ai/code)_